### PR TITLE
Fix Ember 2.6.0 deprecation

### DIFF
--- a/addon/pods/components/frost-list-item/component.js
+++ b/addon/pods/components/frost-list-item/component.js
@@ -5,7 +5,7 @@ import FrostList from '../frost-list/component'
 export default Ember.Component.extend({
   classNameBindings: ['isSelected', 'frost-list-item'],
 
-  initContext: Ember.on('didInitAttrs', function () {
+  initContext: Ember.on('init', function () {
     this.set('_frostList', this.nearestOfType(FrostList))
   }),
 


### PR DESCRIPTION
# PATCH
# CHANGELOG
- **Fixed** deprecation warning from Ember 2.6.0 to stop using `didInitAttrs` hook and instead use `init`.
