### PR TITLE
Reducing ember-cli version to fix a build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "broccoli-asset-rev": "^2.2.0",
     "ember-async-image": "0.1.1",
     "ember-browserify": "1.1.9",
-    "ember-cli": "^2.4.2",
+    "ember-cli": "~2.5.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-blanket": "0.9.4",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
# fix
# CHANGELOG

Locked the ember-cli version to ~2.5.0 to avoid build errors with 2.6
