### PR TITLE
Rename selectedItems and expandedItems

### DIFF
--- a/addon/mixins/frost-list-core-mixin.js
+++ b/addon/mixins/frost-list-core-mixin.js
@@ -28,11 +28,11 @@ export default Mixin.create({
     })
   },
 
-  @computed('listItems.[]', 'selectedItemDictionary', 'expandedItems')
-  statefulListItems (listItems, selectedItemDictionary, expandedItems) {
+  @computed('listItems.[]', 'selectedItemDictionary', 'expandedItemDictionary')
+  statefulListItems (listItems, selectedItemDictionary, expandedItemDictionary) {
     return listItems.map((item) => {
       item.set('isSelected', selectedItemDictionary.getWithDefault(item.id, false))
-      item.set('isExpanded', expandedItems.getWithDefault(item.id, false))
+      item.set('isExpanded', expandedItemDictionary.getWithDefault(item.id, false))
       return item
     })
   }

--- a/addon/mixins/frost-list-core-mixin.js
+++ b/addon/mixins/frost-list-core-mixin.js
@@ -15,7 +15,7 @@ export default Mixin.create({
   }),
 
   @computed('_listItems.[]')
-  listItems (listItems) {
+  wrappedListItems (listItems) {
     if (isNone(listItems)) {
       listItems = []
     }
@@ -28,7 +28,7 @@ export default Mixin.create({
     })
   },
 
-  @computed('listItems.[]', 'selectedItemDictionary', 'expandedItemDictionary')
+  @computed('wrappedListItems.[]', 'selectedItemDictionary', 'expandedItemDictionary')
   statefulListItems (listItems, selectedItemDictionary, expandedItemDictionary) {
     return listItems.map((item) => {
       item.set('isSelected', selectedItemDictionary.getWithDefault(item.id, false))

--- a/addon/mixins/frost-list-core-mixin.js
+++ b/addon/mixins/frost-list-core-mixin.js
@@ -24,10 +24,10 @@ export default Mixin.create({
     })
   },
 
-  @computed('listItems.[]', 'selectedItems', 'expandedItems')
-  statefulListItems (listItems, selectedItems, expandedItems) {
+  @computed('listItems.[]', 'selectedItemDictionary', 'expandedItems')
+  statefulListItems (listItems, selectedItemDictionary, expandedItems) {
     return listItems.map((item) => {
-      item.set('isSelected', selectedItems.getWithDefault(item.id, false))
+      item.set('isSelected', selectedItemDictionary.getWithDefault(item.id, false))
       item.set('isExpanded', expandedItems.getWithDefault(item.id, false))
       return item
     })

--- a/addon/mixins/frost-list-core-mixin.js
+++ b/addon/mixins/frost-list-core-mixin.js
@@ -4,7 +4,8 @@ const {
   get,
   on,
   defineProperty,
-  computed: {alias}
+  computed: {alias},
+  isNone
 } = Ember
 import computed from 'ember-computed-decorators'
 
@@ -15,6 +16,9 @@ export default Mixin.create({
 
   @computed('_listItems.[]')
   listItems (listItems) {
+    if (isNone(listItems)) {
+      listItems = []
+    }
     let wrapper = []
     return listItems.map((item) => {
       return wrapper.pushObject(Ember.Object.create({

--- a/addon/mixins/frost-list-expansion-mixin.js
+++ b/addon/mixins/frost-list-expansion-mixin.js
@@ -10,27 +10,27 @@ import FrostListCoreMixin from 'ember-frost-list/mixins/frost-list-core-mixin'
 export default Mixin.create(FrostListCoreMixin, {
   // == Event =================================================================
   initListExpansionMixin: on('init', function () {
-    set(this, 'expandedItems', Ember.Object.create())
+    set(this, 'expandedItemDictionary', Ember.Object.create())
   }),
 
   // == Actions ================================================================
   actions: {
     collapseItems () {
       let records = get(this, '_listItems')
-      let expandedItems = get(this, 'expandedItems')
+      let expandedItemDictionary = get(this, 'expandedItemDictionary')
       records.map((record) => {
-        delete expandedItems[record.id]
+        delete expandedItemDictionary[record.id]
       })
-      this.notifyPropertyChange('expandedItems')
+      this.notifyPropertyChange('expandedItemDictionary')
     },
 
     expandItems () {
       let records = get(this, '_listItems')
-      let expandedItems = get(this, 'expandedItems')
+      let expandedItemDictionary = get(this, 'expandedItemDictionary')
       records.map((record) => {
-        expandedItems.set(record.id, true)
+        expandedItemDictionary.set(record.id, true)
       })
-      this.notifyPropertyChange('expandedItems')
+      this.notifyPropertyChange('expandedItemDictionary')
     },
 
     collapseItem () {

--- a/addon/mixins/frost-list-mixin.js
+++ b/addon/mixins/frost-list-mixin.js
@@ -67,5 +67,7 @@ export default Mixin.create(FrostListSelectionMixin, FrostListExpansionMixin, Fr
         loadPrevious: get(this, '_loadPrevious')
       }
     }
-  })
+  }),
+  selectedItems: Ember.computed.filterBy('statefulListItems', 'isSelected', true),
+  expandedItems: Ember.computed.filterBy('statefulListItems', 'isExpanded', true)
 })

--- a/addon/mixins/frost-list-selection-mixin.js
+++ b/addon/mixins/frost-list-selection-mixin.js
@@ -5,21 +5,21 @@ const {
   on,
   set
 } = Ember
-import {updateSelectedItemsHash} from 'ember-frost-list/utils/utils'
+import {updateSelectedItemDictionary} from 'ember-frost-list/utils/utils'
 import FrostListCoreMixin from 'ember-frost-list/mixins/frost-list-core-mixin'
 
 export default Mixin.create(FrostListCoreMixin, {
   // == Event =================================================================
   initListSelectionMixin: on('init', function () {
-    set(this, 'selectedItems', Ember.Object.create())
+    set(this, 'selectedItemDictionary', Ember.Object.create())
   }),
 
   // == Actions ================================================================
   actions: {
     selectItem (attrs) {
-      let selectedItems = get(this, 'selectedItems')
-      set(this, 'selectedItems', updateSelectedItemsHash(selectedItems, attrs))
-      this.notifyPropertyChange('selectedItems')
+      let selectedItemDictionary = get(this, 'selectedItemDictionary')
+      set(this, 'selectedItemDictionary', updateSelectedItemDictionary(selectedItemDictionary, attrs))
+      this.notifyPropertyChange('selectedItemDictionary')
     }
   }
 })

--- a/addon/utils/utils.js
+++ b/addon/utils/utils.js
@@ -1,6 +1,6 @@
 import Ember from 'ember'
 
-export function updateSelectedItemsHash (selections, attrs) {
+export function updateSelectedItemDictionary (selections, attrs) {
   let _selections = selections
   if (attrs.selectDesc.isSelected) {
     if (attrs.selectDesc.isShiftSelect) {

--- a/tests/dummy/app/pods/examples/controller.js
+++ b/tests/dummy/app/pods/examples/controller.js
@@ -98,7 +98,7 @@ export default Ember.Controller.extend(FrostListMixin, {
 
     renderDemo (attrs) {
       this.set('selectedItemDictionary', Ember.Object.create())
-      this.set('expandedItems', Ember.Object.create())
+      this.set('expandedItemDictionary', Ember.Object.create())
 
       this.set('renderDemo', true)
 

--- a/tests/dummy/app/pods/examples/controller.js
+++ b/tests/dummy/app/pods/examples/controller.js
@@ -97,7 +97,7 @@ export default Ember.Controller.extend(FrostListMixin, {
     /* eslint-enable complexity */
 
     renderDemo (attrs) {
-      this.set('selectedItems', Ember.Object.create())
+      this.set('selectedItemDictionary', Ember.Object.create())
       this.set('expandedItems', Ember.Object.create())
 
       this.set('renderDemo', true)

--- a/tests/dummy/app/pods/infinite-scroll/controller.js
+++ b/tests/dummy/app/pods/infinite-scroll/controller.js
@@ -13,21 +13,6 @@ export default Ember.Controller.extend(FrostListMixin, {
     return this.store.peekAll('list-item').content.length
   }),
 
-  isButtonActive: computed('selectedItems.[]', function () {
-    let selectedItem = this.get('selectedItems')
-    if (!selectedItem.length) {
-      return {
-        updateButton: true,
-        deleteButton: true
-      }
-    } else {
-      return {
-        updateButton: false,
-        deleteButton: false
-      }
-    }
-  }),
-
   listConfig: {
     items: 'model',
     component: Ember.computed({
@@ -56,7 +41,6 @@ export default Ember.Controller.extend(FrostListMixin, {
   },
 
   alwaysUseDefaultHeight: true,
-  selectedItems: Ember.A(),
   componentPath: computed({
     get () {
       if (config.isFrostGuideDirectory) {

--- a/tests/dummy/app/pods/infinite-scroll/controller.js
+++ b/tests/dummy/app/pods/infinite-scroll/controller.js
@@ -51,7 +51,7 @@ export default Ember.Controller.extend(FrostListMixin, {
     }
   }),
 
-  listItems: Ember.computed('model', function () {
+  wrappedListItems: Ember.computed('model', function () {
     return this.get('model.items')
   }),
 

--- a/tests/dummy/app/pods/pagination/controller.js
+++ b/tests/dummy/app/pods/pagination/controller.js
@@ -8,7 +8,6 @@ export default Ember.Controller.extend(FrostListMixin, {
   },
   itemsPerPage: 10,
   page: 0, // TODO From qp
-  selectedItems: Ember.A(),
   total: 100, // TODO From meta
 
   fetchPage (page) {

--- a/tests/dummy/app/pods/pre-selection/route.js
+++ b/tests/dummy/app/pods/pre-selection/route.js
@@ -13,11 +13,11 @@ export default Ember.Route.extend({
   setupController (controller, model) {
     this._super(controller, model)
 
-    // For demo display only. Create new selectedItems object when entering route.
-    controller.set('selectedItems', Ember.Object.create())
+    // For demo display only. Create new selectedItemDictionary object when entering route.
+    controller.set('selectedItemDictionary', Ember.Object.create())
 
-    controller.selectedItems.set(model.objectAt(0).id, true)
-    controller.selectedItems.set(model.objectAt(2).id, true)
-    controller.selectedItems.set(model.objectAt(4).id, true)
+    controller.selectedItemDictionary.set(model.objectAt(0).id, true)
+    controller.selectedItemDictionary.set(model.objectAt(2).id, true)
+    controller.selectedItemDictionary.set(model.objectAt(4).id, true)
   }
 })

--- a/tests/snippets/controller-no-mixin.js
+++ b/tests/snippets/controller-no-mixin.js
@@ -18,23 +18,23 @@ export default Ember.Controller.extend({
     })
   },
 
-  @computed('listItems.[]', 'selectedItems', 'expandedItems')
-  statefulListItems (listItems, selectedItems, expandedItems) {
+  @computed('listItems.[]', 'selectedItemDictionary', 'expandedItemDictionary')
+  statefulListItems (listItems, selectedItemDictionary, expandedItemDictionary) {
     return listItems.map((item) => {
-      item.set('isSelected', selectedItems.getWithDefault(item.id, false))
-      item.set('isExpanded', expandedItems.getWithDefault(item.id, false))
+      item.set('isSelected', selectedItemDictionary.getWithDefault(item.id, false))
+      item.set('isExpanded', expandedItemDictionary.getWithDefault(item.id, false))
       return item
     })
   },
 
   // == Event =================================================================
   initListSelectionMixin: on('init', function () {
-    this.set('expandedItems', Ember.Object.create())
-    this.set('selectedItems', Ember.Object.create())
+    this.set('expandedItemDictionary', Ember.Object.create())
+    this.set('selectedItemDictionary', Ember.Object.create())
   }),
 
   // == Functions ==============================================================
-  updateSelectedItemsHash (selections, attrs) {
+  updateSelectedItemDictionary (selections, attrs) {
     let _selections = selections
     if (attrs.selectDesc.isSelected) {
       if (attrs.selectDesc.isShiftSelect) {
@@ -82,28 +82,28 @@ export default Ember.Controller.extend({
   // == Actions ===============================================
   actions: {
     selectItem (attrs) {
-      let selectedItems = this.get('selectedItems')
-      this.set('selectedItems',
-        this.updateSelectedItemsHash(selectedItems, attrs))
-      this.notifyPropertyChange('selectedItems')
+      let selectedItemDictionary = this.get('selectedItemDictionary')
+      this.set('selectedItemDictionary',
+        this.updateSelectedItemDictionary(selectedItemDictionary, attrs))
+      this.notifyPropertyChange('selectedItemDictionary')
     },
 
     collapseItems () {
       let records = this.get('listItems')
-      let expandedItems = this.get('expandedItems')
+      let expandedItemDictionary = this.get('expandedItemDictionary')
       records.map((record) => {
-        expandedItems.set(record.id, false)
+        expandedItemDictionary.set(record.id, false)
       })
-      this.notifyPropertyChange('expandedItems')
+      this.notifyPropertyChange('expandedItemDictionary')
     },
 
     expandItems () {
       let records = this.get('listItems')
-      let expandedItems = this.get('expandedItems')
+      let expandedItemDictionary = this.get('expandedItemDictionary')
       records.map((record) => {
-        expandedItems.set(record.id, true)
+        expandedItemDictionary.set(record.id, true)
       })
-      this.notifyPropertyChange('expandedItems')
+      this.notifyPropertyChange('expandedItemDictionary')
     },
 
     collapseItem () {

--- a/tests/snippets/pre-selection-route.js
+++ b/tests/snippets/pre-selection-route.js
@@ -7,8 +7,8 @@ export default Ember.Route.extend({
 
   setupController (controller, model) {
     this._super(controller, model)
-    controller.selectedItems.set(model.objectAt(0).id, true)
-    controller.selectedItems.set(model.objectAt(2).id, true)
-    controller.selectedItems.set(model.objectAt(4).id, true)
+    controller.selectedItemDictionary.set(model.objectAt(0).id, true)
+    controller.selectedItemDictionary.set(model.objectAt(2).id, true)
+    controller.selectedItemDictionary.set(model.objectAt(4).id, true)
   }
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [x] #major# - incompatible API change

# CHANGELOG
- **Renamed** Mixin property selectedItems to selectedItemDictionary.
- **Renamed** Mixin property expandedItems to expandedItemDictionary.
- **Renamed** util function updateSelectedItemsHash to updateSelectedItemDictionary.