### PR TITLE
Fixing a brain-freeze typo in the CSS

### DIFF
--- a/addon/styles/_frost-list-item-element.scss
+++ b/addon/styles/_frost-list-item-element.scss
@@ -76,7 +76,7 @@
   height: 40px;
   margin: 5px 0 5px 5px;
 
-  .frost-svg {
+  .frost-icon {
     width: 40px;
     height: 40px;
   }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Fixed the list-item element icon to target frost-icon instead of frost-svg
