### PR TITLE
Removing unnecessary block-start styles

### DIFF
--- a/addon/styles/_frost-list-item-element.scss
+++ b/addon/styles/_frost-list-item-element.scss
@@ -6,11 +6,6 @@
   padding: 0 7px;
 }
 
-.frost-list-item-element-block-start {
-  margin: 0;
-  padding: 0;
-}
-
 .frost-list-item-element-block ~ .frost-list-item-element-block {
   border-left: 1px solid $frost-color-lgrey-2;
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Removed the list item `block-start` styles since these are already covered in a basic `block`
