### PR TITLE
Comparator functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Sub Attribute`    | `activeSorting`      | `array`          |       | Array that specifies the sort order. eg. [{"direction: "asc/desc", "value": <attr-name>}], This is an attribute on frost-list-expansion component.|
 | `Sub Attribute`    | `properties`         | `array`          |       | Array of sortable attributes. eg. [{"label: "foo", "value": "bar"}], This is an attribute on frost-sort component.|
 | `Sub Attribute`    | `onSort`             | `action closure` |       | callback functions user provided to handle sorting.  This is an attribute on frost-sort component.|
+| `Attribute`        | `itemComparator`     | `action closure` |       | callback functions user provided to handle custom item comparisons.  This is an attribute on frost-list component.|
+
 
 ### Infinite scroll
 

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -99,13 +99,12 @@ export default Component.extend({
       return []
     }
     return items.map(item => {
-      set(
-        item, 'isExpanded',
-        isEmpty(expandedItems) ? false : expandedItems.findIndex(
-          expandedItem => itemComparator(expandedItem, item)) >= 0)
-      set(item, 'isSelected',
-        isEmpty(selectedItems) ? false : selectedItems.findIndex(
-          selectedItem => itemComparator(selectedItem, item)) >= 0)
+      set(item, 'isExpanded', isEmpty(expandedItems) ? false : expandedItems.some(
+        selectedItem => itemComparator(selectedItem, item))
+      )
+      set(item, 'isSelected', isEmpty(selectedItems) ? false : selectedItems.some(
+        selectedItem => itemComparator(selectedItem, item))
+      )
       return item
     })
   },

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -151,8 +151,10 @@ export default Component.extend({
 
     _expand (item) {
       const clonedExpandedItems = A(this.get('expandedItems').slice())
-      if (clonedExpandedItems.indexOf(item) >= 0) {
-        clonedExpandedItems.removeObject(item)
+      const itemComparator = this.get('itemComparator')
+      const index = clonedExpandedItems.findIndex(expandedItem => itemComparator(expandedItem, item))
+      if (index >= 0) {
+        clonedExpandedItems.removeAt(index)
       } else {
         clonedExpandedItems.pushObject(item)
       }

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -53,6 +53,7 @@
       {{#if itemExpansion}}
         {{frost-list-item-expansion
           hook=(concat hookPrefix '-expansion')
+          hookQualifiers=(hash index=index)
           model=model
           onExpand=(action '_expand')
         }}

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -46,8 +46,9 @@
     {{if (eq index 0) ' first'}}
     {{if (eq index (sub _items.length 1)) ' last'}}
     {{if model.isSelected ' is-selected'}}
-    {{if (is-lead-selection _items model) ' is-lead-selection'}}
-  '>
+    {{if (is-lead-selection _items model) ' is-lead-selection'}}'
+       data-test={{hook (concat hook '-item-container') index=index }}
+  >
     <div class='frost-list-item-container-base'>
       {{#if itemExpansion}}
         {{frost-list-item-expansion

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -47,7 +47,7 @@
     {{if (eq index (sub _items.length 1)) ' last'}}
     {{if model.isSelected ' is-selected'}}
     {{if (is-lead-selection _items model) ' is-lead-selection'}}'
-       data-test={{hook (concat hook '-item-container') index=index }}
+    data-test={{hook (concat hook '-item-container') index=index }}
   >
     <div class='frost-list-item-container-base'>
       {{#if itemExpansion}}
@@ -61,6 +61,7 @@
       {{#if onSelectionChange}}
         {{frost-list-item-selection
           hook=(concat hookPrefix '-selection')
+          hookQualifiers=(hash index=index)
           model=model
           onSelect=(action '_select')
         }}

--- a/addon/utils/selection.js
+++ b/addon/utils/selection.js
@@ -17,10 +17,12 @@ export default {
    * @param {Object[]} selectedItems - currently selected items
    * @param {Object} item - selection event target
    * @param {Object} rangeState - tracking the anchor and endpoint
+   * @param {Function} itemComparator - comparator for items
    */
-  basic (selectedItems, item, rangeState) {
+  basic (selectedItems, item, rangeState, itemComparator) {
     // If a previous set of selections is present
-    if (selectedItems.get('length') > 1 || selectedItems.indexOf(item) === -1) {
+    const index = selectedItems.findIndex(selectedItem => itemComparator(selectedItem, item))
+    if (selectedItems.get('length') > 1 || index === -1) {
       // Clear the other selections and select the item
       selectedItems.setObjects([item])
 
@@ -31,15 +33,17 @@ export default {
       rangeState['endpoint'] = null
     } else {
       // Toggle the item selection
-      const isCurrentlySelected = selectedItems.indexOf(item) >= 0
+
+      const isCurrentlySelected = (index >= 0)
       const isSelected = !isCurrentlySelected
       if (isSelected) {
         selectedItems.pushObject(item)
       } else {
-        selectedItems.removeObject(item)
+        selectedItems.removeAt(index)
+        // selectedItems.removeObject(item)
       }
 
-       // Set the range anchor if selected, otherwise clear the anchor
+      // Set the range anchor if selected, otherwise clear the anchor
       rangeState['anchor'] = isSelected ? item : null
 
       // New or no anchor, clear any previous endpoint
@@ -57,9 +61,10 @@ export default {
    * @param {Object[]} selectedItems - currently selected items
    * @param {Object} item - selection event target
    * @param {Object} rangeState - tracking the anchor and endpoint
+   * @param {Function} itemComparator - comparator for items
    */
   /* eslint-disable complexity */
-  range (items, selectedItems, item, rangeState) {
+  range (items, selectedItems, item, rangeState, itemComparator) {
     // If an anchor isn't set, then set the anchor and exit
     const rangeAnchor = rangeState['anchor']
     if (isNone(rangeAnchor)) {
@@ -76,8 +81,8 @@ export default {
     }
 
     // Find the indicies of the anchor and endpoint
-    const anchor = items.indexOf(rangeState['anchor'])
-    const endpoint = items.indexOf(item)
+    const anchor = items.findIndex(currentItem => itemComparator(currentItem, rangeState['anchor']))
+    const endpoint = items.findIndex(currentItem => itemComparator(currentItem, item))
 
     // Select all of the items between the anchor and the item (inclusive)
     if (anchor < endpoint) {
@@ -88,7 +93,8 @@ export default {
 
     // If an endpoint was already selected remove selected items that were
     // in the previous range but aren't in the new range
-    const previousEndpoint = items.indexOf(rangeState['endpoint'])
+    // const previousEndpoint = items.indexOf(rangeState['endpoint'])
+    const previousEndpoint = items.findIndex(currentItem => itemComparator(currentItem, rangeState['endpoint']))
     if (previousEndpoint >= 0) {
       // If both endpoints are above the anchor
       if (anchor < endpoint && anchor < previousEndpoint) {
@@ -122,9 +128,11 @@ export default {
    * @param {Object[]} selectedItems - currently selected items
    * @param {Object} item - selection event target
    * @param {Object} rangeState - tracking the anchor and endpoint
+   * @param {Function} itemComparator - comparator for items
    */
-  specific (selectedItems, item, rangeState) {
-    const isCurrentlySelected = selectedItems.indexOf(item) >= 0
+  specific (selectedItems, item, rangeState, itemComparator) {
+    const index = selectedItems.findIndex(selectedItem => itemComparator(selectedItem, item))
+    const isCurrentlySelected = (index >= 0)
     const isSelected = !isCurrentlySelected
 
     // Set the range anchor if selected, otherwise clear the anchor
@@ -136,7 +144,7 @@ export default {
     if (isSelected) {
       selectedItems.pushObject(item)
     } else {
-      selectedItems.removeObject(item)
+      selectedItems = selectedItems.splice(index, 1)
     }
   }
 }

--- a/addon/utils/selection.js
+++ b/addon/utils/selection.js
@@ -40,7 +40,6 @@ export default {
         selectedItems.pushObject(item)
       } else {
         selectedItems.removeAt(index)
-        // selectedItems.removeObject(item)
       }
 
       // Set the range anchor if selected, otherwise clear the anchor
@@ -93,7 +92,6 @@ export default {
 
     // If an endpoint was already selected remove selected items that were
     // in the previous range but aren't in the new range
-    // const previousEndpoint = items.indexOf(rangeState['endpoint'])
     const previousEndpoint = items.findIndex(currentItem => itemComparator(currentItem, rangeState['endpoint']))
     if (previousEndpoint >= 0) {
       // If both endpoints are above the anchor

--- a/addon/utils/selection.js
+++ b/addon/utils/selection.js
@@ -142,7 +142,7 @@ export default {
     if (isSelected) {
       selectedItems.pushObject(item)
     } else {
-      selectedItems = selectedItems.splice(index, 1)
+      selectedItems.removeAt(index)
     }
   }
 }

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -143,11 +143,11 @@ describe(test.label, function () {
     })
 
     it('item 0 is selected', function () {
-      expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+      expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
     })
 
     it('item 1 is not selected', function () {
-      expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+      expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
     })
   })
 
@@ -179,10 +179,10 @@ describe(test.label, function () {
     })
 
     it('item 0 is selected', function () {
-      expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+      expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
     })
     it('item 1 is not selected', function () {
-      expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+      expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
     })
 
     describe('when itemComparator set back to default', function () {
@@ -198,10 +198,10 @@ describe(test.label, function () {
         return wait()
       })
       it('item 0 not selected ', function () {
-        expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
       })
       it('item 1 not selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
       })
     })
   })
@@ -234,106 +234,108 @@ describe(test.label, function () {
 
     describe('when doing basic click', function () {
       beforeEach(function () {
-        this.$(hook('my-list-item', {index: 0})).click()
+        $(hook('my-list-item', {index: 0})).click()
         return wait()
       })
 
       it('item 0 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
       })
 
       it('item 1 is not selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
       })
 
       describe('when doing basic click on previous selected item', function () {
         beforeEach(function () {
-          this.$(hook('my-list-item', {index: 0})).click()
+          $(hook('my-list-item', {index: 0})).click()
           return wait()
         })
 
         it('item 0 is not selected', function () {
-          expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+          expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
         })
 
         it('item 1 is not selected', function () {
-          expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+          expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
         })
       })
     })
 
     describe('when doing basic click and all is selected', function () {
       beforeEach(function () {
-        this.$($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
-        this.$($(hook('my-list-item-container', {index: 1})).find(hook('my-list-selection-checkbox'))).click()
-        this.$(hook('my-list-item', {index: 0})).click()
+        $(hook('my-list-selection', {index:0})).click()
+        $(hook('my-list-selection', {index:1})).click()
+        $(hook('my-list-item', {index: 0})).click()
         return wait()
       })
 
       it('item 0 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
       })
 
       it('item 1 is not selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
       })
     })
 
     describe('when doing specific click on one item', function () {
       beforeEach(function () {
-        this.$($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
+        $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
         return wait()
       })
 
       it('item 0 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
       })
       it('item 1 is not selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
       })
 
       describe('when doing specific click to unselect previous item', function () {
         beforeEach(function () {
-          this.$($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
+          $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
           return wait()
         })
 
         it('item 0 is not selected', function () {
-          expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+          expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
         })
         it('item 1 is not selected', function () {
-          expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+          expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
         })
       })
     })
 
-    describe('when doing specific click on each items', function () {
+    describe('when doing specific click on each item', function () {
       beforeEach(function () {
-        this.$($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
-        this.$($(hook('my-list-item-container', {index: 1})).find(hook('my-list-selection-checkbox'))).click()
+        $(hook('my-list-selection', {index:0})).click()
+        $(hook('my-list-selection', {index:1})).click()
         return wait()
       })
 
       it('item 0 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
       })
       it('item 1 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(true)
       })
 
       describe('when doing specific click to unselect each items', function () {
         beforeEach(function () {
-          this.$($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
-          this.$($(hook('my-list-item-container', {index: 1})).find(hook('my-list-selection-checkbox'))).click()
+          $(hook('my-list-selection', {index:0})).click()
+          $(hook('my-list-selection', {index:1})).click()
+          // $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
+          // $($(hook('my-list-item-container', {index: 1})).find(hook('my-list-selection-checkbox'))).click()
           return wait()
         })
 
         it('item 0 is not selected', function () {
-          expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+          expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
         })
 
         it('item 1 is not selected', function () {
-          expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+          expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
         })
       })
     })
@@ -376,31 +378,31 @@ describe(test.label, function () {
         clickEvent.shiftKey = true
         const clickEvent2 = $.Event('click')
         clickEvent2.shiftKey = true
-        this.$(hook('my-list-item', {index: 1})).trigger(clickEvent)
-        this.$(hook('my-list-item', {index: 5})).trigger(clickEvent2)
+        $(hook('my-list-item', {index: 1})).trigger(clickEvent)
+        $(hook('my-list-item', {index: 5})).trigger(clickEvent2)
         return wait()
       })
 
       it('item 0 is not selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
       })
       it('item 1 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(true)
       })
       it('item 2 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 2})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 2})).hasClass('is-selected')).to.eql(true)
       })
       it('item 3 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 3})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 3})).hasClass('is-selected')).to.eql(true)
       })
       it('item 4 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 4})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 4})).hasClass('is-selected')).to.eql(true)
       })
       it('item 5 is selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 5})).hasClass('is-selected')).to.eql(true)
+        expect($($hook('my-list-item-container', {index: 5})).hasClass('is-selected')).to.eql(true)
       })
       it('item 6 is not selected', function () {
-        expect(this.$($hook('my-list-item-container', {index: 6})).hasClass('is-selected')).to.eql(false)
+        expect($($hook('my-list-item-container', {index: 6})).hasClass('is-selected')).to.eql(false)
       })
     })
   })

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -264,8 +264,8 @@ describe(test.label, function () {
 
     describe('when doing basic click and all is selected', function () {
       beforeEach(function () {
-        $(hook('my-list-selection', {index:0})).click()
-        $(hook('my-list-selection', {index:1})).click()
+        $(hook('my-list-selection', {index: 0})).click()
+        $(hook('my-list-selection', {index: 1})).click()
         $(hook('my-list-item', {index: 0})).click()
         return wait()
       })
@@ -309,8 +309,8 @@ describe(test.label, function () {
 
     describe('when doing specific click on each item', function () {
       beforeEach(function () {
-        $(hook('my-list-selection', {index:0})).click()
-        $(hook('my-list-selection', {index:1})).click()
+        $(hook('my-list-selection', {index: 0})).click()
+        $(hook('my-list-selection', {index: 1})).click()
         return wait()
       })
 
@@ -323,8 +323,8 @@ describe(test.label, function () {
 
       describe('when doing specific click to unselect each items', function () {
         beforeEach(function () {
-          $(hook('my-list-selection', {index:0})).click()
-          $(hook('my-list-selection', {index:1})).click()
+          $(hook('my-list-selection', {index: 0})).click()
+          $(hook('my-list-selection', {index: 1})).click()
           // $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
           // $($(hook('my-list-item-container', {index: 1})).find(hook('my-list-selection-checkbox'))).click()
           return wait()

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -143,11 +143,11 @@ describe(test.label, function () {
     })
 
     it('item 0 is selected', function () {
-      expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+      expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
     })
 
     it('item 1 is not selected', function () {
-      expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+      expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
     })
   })
 
@@ -179,10 +179,10 @@ describe(test.label, function () {
     })
 
     it('item 0 is selected', function () {
-      expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+      expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
     })
     it('item 1 is not selected', function () {
-      expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+      expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
     })
 
     describe('when itemComparator set back to default', function () {
@@ -198,10 +198,10 @@ describe(test.label, function () {
         return wait()
       })
       it('item 0 not selected ', function () {
-        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
       })
       it('item 1 not selected', function () {
-        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
       })
     })
   })
@@ -239,11 +239,11 @@ describe(test.label, function () {
       })
 
       it('item 0 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
       })
 
       it('item 1 is not selected', function () {
-        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
       })
 
       describe('when doing basic click on previous selected item', function () {
@@ -253,11 +253,11 @@ describe(test.label, function () {
         })
 
         it('item 0 is not selected', function () {
-          expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+          expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
         })
 
         it('item 1 is not selected', function () {
-          expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+          expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
         })
       })
     })
@@ -271,30 +271,30 @@ describe(test.label, function () {
       })
 
       it('item 0 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
       })
 
       it('item 1 is not selected', function () {
-        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
       })
     })
 
     describe('when doing specific click on one item', function () {
       beforeEach(function () {
-        $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
+        $hook('my-list-selection', {index: 0}).click()
         return wait()
       })
 
       it('item 0 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
       })
       it('item 1 is not selected', function () {
-        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
       })
 
       describe('when doing specific click to unselect previous item', function () {
         beforeEach(function () {
-          $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
+          $hook('my-list-selection', {index: 0}).click()
           return wait()
         })
 
@@ -309,33 +309,31 @@ describe(test.label, function () {
 
     describe('when doing specific click on each item', function () {
       beforeEach(function () {
-        $(hook('my-list-selection', {index: 0})).click()
-        $(hook('my-list-selection', {index: 1})).click()
+        $hook('my-list-selection', {index: 0}).click()
+        $hook('my-list-selection', {index: 1}).click()
         return wait()
       })
 
       it('item 0 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
       })
       it('item 1 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
       })
 
       describe('when doing specific click to unselect each items', function () {
         beforeEach(function () {
-          $(hook('my-list-selection', {index: 0})).click()
-          $(hook('my-list-selection', {index: 1})).click()
-          // $($(hook('my-list-item-container', {index: 0})).find(hook('my-list-selection-checkbox'))).click()
-          // $($(hook('my-list-item-container', {index: 1})).find(hook('my-list-selection-checkbox'))).click()
+          $hook('my-list-selection', {index: 0}).click()
+          $hook('my-list-selection', {index: 1}).click()
           return wait()
         })
 
         it('item 0 is not selected', function () {
-          expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+          expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
         })
 
         it('item 1 is not selected', function () {
-          expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+          expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
         })
       })
     })
@@ -359,7 +357,6 @@ describe(test.label, function () {
       this.set('onSelectionChange', (selectedItems) => {
         this.get('selectedItems').setObjects(selectedItems)
       })
-
       this.render(hbs`
         {{frost-list
           item=(component 'frost-list-item')
@@ -384,25 +381,77 @@ describe(test.label, function () {
       })
 
       it('item 0 is not selected', function () {
-        expect($($hook('my-list-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
       })
       it('item 1 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 1})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
       })
       it('item 2 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 2})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
       })
       it('item 3 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 3})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
       })
       it('item 4 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 4})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
       })
       it('item 5 is selected', function () {
-        expect($($hook('my-list-item-container', {index: 5})).hasClass('is-selected')).to.eql(true)
+        expect($hook('my-list-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
       })
       it('item 6 is not selected', function () {
-        expect($($hook('my-list-item-container', {index: 6})).hasClass('is-selected')).to.eql(false)
+        expect($hook('my-list-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+      })
+    })
+  })
+
+  describe('supports item expansion', function () {
+    beforeEach(function () {
+      const testItems = A([
+        Ember.Object.create({id: '0'}),
+        Ember.Object.create({id: '1'})
+      ])
+      this.set('items', testItems)
+      this.set('selectedItems', A([]))
+      this.set('expandedItems', A([]))
+      this.set('onSelectionChange', (selectedItems) => {
+        this.get('selectedItems').setObjects(selectedItems)
+      })
+      this.set('onExpansionChange', (expandedItems) => {
+        this.get('expandedItems').setObjects(expandedItems)
+      })
+      this.render(hbs`
+        {{frost-list
+          item=(component 'frost-list-item')
+          itemExpansion=(component 'frost-list-item')
+          hook='my-list'
+          items=items
+          selectedItems=selectedItems
+          onSelectionChange=onSelectionChange
+          onExpansionChange=onExpansionChange
+          expandedItems=expandedItems
+        }}
+      `)
+      return wait()
+    })
+
+    describe('clicking item 0 expansion button', function () {
+      beforeEach(function () {
+        $hook('my-list-expansion', {index: 0}).click()
+        return wait()
+      })
+
+      it('item 0 is expanded', function () {
+        expect($hook('my-list-item-expansion', {index: 0})).to.have.length(1)
+      })
+
+      describe('clicking item 0 expansion button', function () {
+        beforeEach(function () {
+          $hook('my-list-expansion', {index: 0}).click()
+          return wait()
+        })
+        it('item 0 is not expanded', function () {
+          expect($hook('my-list-item-expansion', {index: 0})).to.have.length(0)
+        })
       })
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Added a default comparator which can be overridden with a custom comparator.
* Added tests for three scenarios of clicking
* Modified frost-list template to have a hook at the top of the container for easier testing of items below it.