### PR TITLE
Fr/optional basic click

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Sub Attribute`    | `activeSorting`      | `array`          |       | Array that specifies the sort order. eg. [{"direction: "asc/desc", "value": <attr-name>}], This is an attribute on frost-list-expansion component.|
 | `Sub Attribute`    | `properties`         | `array`          |       | Array of sortable attributes. eg. [{"label: "foo", "value": "bar"}], This is an attribute on frost-sort component.|
 | `Sub Attribute`    | `onSort`             | `action closure` |       | callback functions user provided to handle sorting.  This is an attribute on frost-sort component.|
-| `Attribute`        | `itemComparator`     | `action closure` |       | callback functions user provided to handle custom item comparisons.  This is an attribute on frost-list component.|
+| `Attribute`        | `itemComparator`     | `action closure` |       | callback functions user provided to handle custom item comparisons.|
+| `Attribute`        | `basicClickDisabled` | `boolean`        |       | Optional: set to true if you want to disable basic clicks, else false by default.|
 
 
 ### Infinite scroll

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -43,6 +43,7 @@ export default Component.extend({
     ])),
     onSelectionChange: PropTypes.func,
     itemComparator: PropTypes.func,
+    basicClickDisabled: PropTypes.bool,
 
     // Options - sub-components
     pagination: PropTypes.EmberComponent,
@@ -76,6 +77,7 @@ export default Component.extend({
       // Options - general
       scrollTop: 0,
       itemComparator: (rhs, lhs) => { return rhs === lhs },
+      basicClickDisabled: false,
 
       // Smoke and mirrors options
       alwaysUseDefaultHeight: false,
@@ -167,18 +169,23 @@ export default Component.extend({
 
     _select ({isRangeSelect, isSpecificSelect, item}) {
       const items = this.get('items')
+      const itemComparator = this.get('itemComparator')
+      const basicClickDisabled = this.get('basicClickDisabled')
       const clonedSelectedItems = A(this.get('selectedItems').slice())
       const _rangeState = this.get('_rangeState')
 
       // Selects are proccessed in order of precedence: specific, range, basic
       if (isSpecificSelect) {
-        selection.specific(clonedSelectedItems, item, _rangeState, this.get('itemComparator'))
+        selection.specific(clonedSelectedItems, item, _rangeState, itemComparator)
       } else if (isRangeSelect) {
-        selection.range(items, clonedSelectedItems, item, _rangeState, this.get('itemComparator'))
+        selection.range(items, clonedSelectedItems, item, _rangeState, itemComparator)
       } else {
-        selection.basic(clonedSelectedItems, item, _rangeState, this.get('itemComparator'))
+        if (basicClickDisabled) {
+          selection.specific(clonedSelectedItems, item, _rangeState, itemComparator)
+        } else {
+          selection.basic(clonedSelectedItems, item, _rangeState, itemComparator)
+        }
       }
-
       this.onSelectionChange(clonedSelectedItems)
     }
   }

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -339,6 +339,58 @@ describe(test.label, function () {
     })
   })
 
+  describe('when setting basicClickDisabled=true and using basic clicks', function () {
+    beforeEach(function () {
+      const testItems = A([
+        Ember.Object.create({id: '0'}),
+        Ember.Object.create({id: '1'})
+      ])
+
+      this.set('items', testItems)
+      const testSelectedItems = A([])
+      this.set('selectedItems', testSelectedItems)
+      this.set('onSelectionChange', (selectedItems) => {
+        this.get('selectedItems').setObjects(selectedItems)
+      })
+      this.render(hbs`
+        {{frost-list
+          basicClickDisabled=true
+          item=(component 'frost-list-item')
+          hook='my-list'
+          items=items
+          selectedItems=selectedItems
+          onSelectionChange=onSelectionChange
+        }}
+      `)
+      return wait()
+    })
+
+    describe('when selecting both items', function () {
+      beforeEach(function () {
+        $(hook('my-list-item', {index: 0})).click()
+        $(hook('my-list-item', {index: 1})).click()
+      })
+      it('item 0 is selected', function () {
+        expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+      })
+      it('item 1 is selected', function () {
+        expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+      })
+
+      describe('when unselecting item 0', function () {
+        beforeEach(function () {
+          $(hook('my-list-item', {index: 0})).click()
+        })
+        it('item 0 is not selected', function () {
+          expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+        })
+        it('item 1 is selected', function () {
+          expect($hook('my-list-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+        })
+      })
+    })
+  })
+
   describe('supports ranged based clicks', function () {
     beforeEach(function () {
       const testItems = A([
@@ -403,7 +455,6 @@ describe(test.label, function () {
       })
     })
   })
-
   describe('supports item expansion', function () {
     beforeEach(function () {
       const testItems = A([


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Added the ability to disable a basic click. While basic click is nice, it is not always desirable. If you had a list of 100+ items and you accidentally clicked a item, you will unselect all. 