### PR TITLE
Updated Readme again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: true
+    tags: false
 after_deploy:
 - ".travis/publish-gh-pages.sh"
 notifications:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Sub Attribute`    | `properties`         | `array`          |       | Array of sortable attributes. eg. [{"label: "foo", "value": "bar"}], This is an attribute on frost-sort component.|
 | `Sub Attribute`    | `onSort`             | `action closure` |       | callback functions user provided to handle sorting.  This is an attribute on frost-sort component.|
 | `Attribute`        | `itemComparator`     | `action closure` |       | callback functions user provided to handle custom item comparisons.|
-| `Attribute`        | `basicClickDisabled` | `boolean`        |       | Optional: set to true if you want to disable basic clicks, else false by default.|
+| `Attribute`        | `basicClickDisabled` | `boolean`        |       | Optional: set to true if you want to disable basic clicks, else false by default. Basic clicks select the item you clicked while deselecting everything else|
 
 
 ### Infinite scroll

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -175,18 +175,16 @@ export default Component.extend({
       const basicClickDisabled = this.get('basicClickDisabled')
       const clonedSelectedItems = A(this.get('selectedItems').slice())
       const _rangeState = this.get('_rangeState')
-
+      if (basicClickDisabled){
+        isSpecificSelect = true
+      }
       // Selects are proccessed in order of precedence: specific, range, basic
       if (isSpecificSelect) {
         selection.specific(clonedSelectedItems, item, _rangeState, itemComparator)
       } else if (isRangeSelect) {
         selection.range(items, clonedSelectedItems, item, _rangeState, itemComparator)
       } else {
-        if (basicClickDisabled) {
-          selection.specific(clonedSelectedItems, item, _rangeState, itemComparator)
-        } else {
-          selection.basic(clonedSelectedItems, item, _rangeState, itemComparator)
-        }
+        selection.basic(clonedSelectedItems, item, _rangeState, itemComparator)
       }
       this.onSelectionChange(clonedSelectedItems)
     }

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -175,7 +175,7 @@ export default Component.extend({
       const basicClickDisabled = this.get('basicClickDisabled')
       const clonedSelectedItems = A(this.get('selectedItems').slice())
       const _rangeState = this.get('_rangeState')
-      if (basicClickDisabled){
+      if (basicClickDisabled) {
         isSpecificSelect = true
       }
       // Selects are proccessed in order of precedence: specific, range, basic

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -345,7 +345,6 @@ describe(test.label, function () {
         Ember.Object.create({id: '0'}),
         Ember.Object.create({id: '1'})
       ])
-
       this.set('items', testItems)
       const testSelectedItems = A([])
       this.set('selectedItems', testSelectedItems)
@@ -367,8 +366,9 @@ describe(test.label, function () {
 
     describe('when selecting both items', function () {
       beforeEach(function () {
-        $(hook('my-list-item', {index: 0})).click()
-        $(hook('my-list-item', {index: 1})).click()
+        $hook('my-list-item', {index: 0}).click()
+        $hook('my-list-item', {index: 1}).click()
+        return wait()
       })
       it('item 0 is selected', function () {
         expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
@@ -379,7 +379,8 @@ describe(test.label, function () {
 
       describe('when unselecting item 0', function () {
         beforeEach(function () {
-          $(hook('my-list-item', {index: 0})).click()
+          $hook('my-list-item', {index: 0}).click()
+          return wait()
         })
         it('item 0 is not selected', function () {
           expect($hook('my-list-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: #103

# CHANGELOG

* Publish PR #104, #105, and #106, which included:
* **Added** optional `basicClickDisabled` attribute. While basic click is nice, it is not always desirable. If you have a list of 100+ selected items, a mis-click might reset your selections.
* **Fixed** issue with Ember 2.11 and run loop
* **Added** a default comparator which can be overridden with a custom comparator
* **Added** tests for three scenarios of clicking
* **Added** an ember hook selector to frost-list-item-container
