### PR TITLE
Performance

### DIFF
--- a/addon/styles/_frost-list-item-container.scss
+++ b/addon/styles/_frost-list-item-container.scss
@@ -1,35 +1,21 @@
 .frost-list-item-container {
-  padding: 0 1px 1px;
-  border-top: 1px solid $frost-color-lgrey-1;
+  margin: 1px;
+  outline: 1px solid $frost-color-lgrey-1;
 
   &:hover {
-    & .frost-list-item-container-base,
-    & .frost-list-item-container-expansion {
+    .frost-list-item-container-base,
+    .frost-list-item-container-expansion {
       background-color: $frost-list-item-hover-color;
       cursor: pointer;
     }
   }
 
   &.is-selected {
-    padding: 0;
-    border-right: 1px solid $frost-color-blue-1;
-    border-bottom: 1px solid $frost-color-blue-1;
-    border-left: 1px solid $frost-color-blue-1;
-
-    &.is-lead-selection {
-      border-top: 1px solid $frost-color-blue-1;
-    }
+    position: relative;
+    outline: 1px solid $frost-color-blue-1;
+    z-index: 1;
   }
 
-  &.first {
-    padding-top: 1px;
-    border-top: 0;
-
-    &.is-selected {
-      padding-top: 0;
-      border-top: 1px solid $frost-color-blue-1;
-    }
-  }
 
   // The last list item container is given a class so that it can be targeted
   // This is primarily to support the case where additional bottom margin needs

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -6,6 +6,8 @@
   }}
     {{#each items as |model index|}}
       {{yield model index}}
+    {{else}}
+      {{yield to="inverse"}}
     {{/each}}
   {{/frost-scroll}}
 {{else}}
@@ -36,5 +38,7 @@
     as |model index|
   }}
     {{yield model index}}
+  {{else}}
+    {{yield to="inverse"}}
   {{/vertical-collection}}
 {{/if}}

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -45,8 +45,7 @@
     frost-list-item-container
     {{if (eq index 0) ' first'}}
     {{if (eq index (sub _items.length 1)) ' last'}}
-    {{if model.isSelected ' is-selected'}}
-    {{if (is-lead-selection _items model) ' is-lead-selection'}}'
+    {{if model.isSelected ' is-selected'}}'
     data-test={{hook (concat hook '-item-container') index=index }}
   >
     <div class='frost-list-item-container-base'>
@@ -87,5 +86,7 @@
       </div>
     {{/if}}
   </div>
+{{else}}
+  {{yield to="inverse"}}
 {{/frost-list-content-container}}
 <div class='frost-list-content-container-bottom-border {{if pagination 'paged'}}'></div>


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

`O(n)` operations are performed whenever `is-lead-selection` helper is fired; frost-list-item-container is rendered, or an item is modified. Not too much of an issue when dealing with a small list of elements, but not too scalable in terms of performance.

By using outline instead of border, you don't have to worry about the size of the content changing.

## Using Border
![screen shot 2017-02-21 at 3 00 47 pm](https://cloud.githubusercontent.com/assets/7063255/23182456/924863e0-f846-11e6-8990-e43edd74a554.png)

## Using Outline
![screen shot 2017-02-21 at 3 01 25 pm](https://cloud.githubusercontent.com/assets/7063255/23182491/afd16eb6-f846-11e6-8b29-d46a827e4dc3.png)

Yield to inverse can be used when a list of items is empty.

Example

```
 {{frost-list items=emptyList}}
 {{else}}
   No content is available
 {{/frost-list}}
```

# CHANGELOG
- Added `{{yield to='inverse'}}` when no content is present to improve usability
- Changed outline to border to avoid computations
