### PR TITLE
fix(temp): Use fork of smoke-and-mirrors

### DIFF
--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -41,11 +41,12 @@
   onLoadPrevious=onLoadPrevious
   as |model index|
 }}
-  <div class='
-    frost-list-item-container
-    {{if (eq index 0) ' first'}}
-    {{if (eq index (sub _items.length 1)) ' last'}}
-    {{if model.isSelected ' is-selected'}}'
+  <div class={{concat
+      'frost-list-item-container'
+      (if (eq index 0) ' first')
+      (if (eq index (sub _items.length 1)) ' last')
+      (if model.isSelected ' is-selected')
+    }}
     data-test={{hook (concat hook '-item-container') index=index }}
   >
     <div class='frost-list-item-container-base'>

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "loader.js": "^4.0.0",
     "pull-report": "^0.3.1",
     "sinon-chai": "^2.8.0",
-    "smoke-and-mirrors": "~0.6.2"
+    "smoke-and-mirrors": "github:ciena-frost/smoke-and-mirrors"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- Pull in temporary fork of s&m (pre 1.0.0)
- Remove whitespace in content-container className