### PR TITLE
Unregister event handler

### DIFF
--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -117,9 +117,11 @@ export default Component.extend({
   // == Functions =============================================================
 
   setShift (event) {
-    if (!this.isDestroyed) {
-      this.set('_isShiftDown', event.shiftKey)
-    }
+    run.next(() => {
+      if (!this.isDestroyed) {
+        this.set('_isShiftDown', event.shiftKey)
+      }
+    })
   },
 
   // == DOM Events ============================================================

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -150,11 +150,12 @@ export default Component.extend({
       })
     }
 
-    $(document).on(`keyup.${this.elementId} keydown.${this.elementId}`, this.setShift.bind(this))
+    this._keyHandler = this.setShift.bind(this)
+    $(document).on(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
   },
 
   willDestroy () {
-    $(document).off(`keyup.${this.elementId} keydown.${this.elementId}`, this.setShift.bind(this))
+    $(document).off(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
   },
 
   // == Actions ===============================================================

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -118,9 +118,10 @@ export default Component.extend({
 
   setShift (event) {
     run.next(() => {
-      if (!this.isDestroyed) {
-        this.set('_isShiftDown', event.shiftKey)
+      if (this.isDestroyed || this.isDestroying) {
+        return
       }
+      this.set('_isShiftDown', event.shiftKey)
     })
   },
 


### PR DESCRIPTION
- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** memory leak by removing the original event handler for `keyup/down` events.
