### PR TITLE
Fixed font weight for list item element label

### DIFF
--- a/addon/styles/_frost-list-item-element.scss
+++ b/addon/styles/_frost-list-item-element.scss
@@ -92,7 +92,7 @@
 .frost-list-item-element-label {
   margin-right: 5px;
   color: $frost-color-grey-5;
-  font-weight: 700;
+  font-weight: 500;
 }
 
 .frost-list-item-element-progress {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** `font-weight` for `list-item-element-label`