### PR TITLE
[Bugfix] Expand All handling of model items

### DIFF
--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -203,7 +203,8 @@ export default Component.extend({
     },
 
     _expandAll () {
-      this.onExpansionChange(this.get('items'))
+      const clonedItems = A(this.get('items').slice())
+      this.onExpansionChange(clonedItems)
     },
 
     _select ({isRangeSelect, isSpecificSelect, item}) {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "ember-export-application-global": "^1.0.4",
     "ember-frost-test": "1.0.1",
     "ember-get-config": "0.2.1",
-    "ember-hash-helper-polyfill": "0.1.2",
     "ember-hook": "1.4.1",
     "ember-load-initializers": "0.6.3",
     "ember-prop-types": "^3.10.3",

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -1117,5 +1117,20 @@ describe(test.label, function () {
         })
       })
     })
+
+    describe('clicking Expand All button', function () {
+      beforeEach(function () {
+        $hook('myList-expansion-expand-all').click()
+        return wait()
+      })
+
+      it('item 0 is expanded', function () {
+        expect($hook('myList-item-expansion', {index: 0})).to.have.length(1)
+      })
+
+      it('item 1 is expanded', function () {
+        expect($hook('myList-item-expansion', {index: 1})).to.have.length(1)
+      })
+    })
   })
 })


### PR DESCRIPTION

### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** Expand All handling of model items
* Removed unnecessary ember-hash-helper-polyfill
