### PR TITLE
Expose `itemKey` as a configurable property

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-release
+  - node_js: 'stable'
 
 before_install:
 - npm config set spin false

--- a/addon/components/frost-list-content-container.js
+++ b/addon/components/frost-list-content-container.js
@@ -7,7 +7,6 @@ const {isNone} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {PropTypes} from 'ember-prop-types'
-import {animate} from 'liquid-fire'
 
 import layout from '../templates/components/frost-list-content-container'
 
@@ -50,26 +49,9 @@ export default Component.extend({
   @computed('pagination')
   paged (pagination) {
     return !isNone(pagination)
-  },
+  }
 
   // == Functions =============================================================
-
-  _transition () {
-    this.transition(
-      this.use(function (opts = {duration: 300}) {
-        if (this.oldElement) {
-          this.oldElement.css('opacity', 1)
-        }
-        if (this.newElement) {
-          this.newElement.css('opacity', 0)
-        }
-
-        return animate(this.oldElement, {opacity: 0}, opts).then(() => {
-          return animate(this.newElement, {opacity: 1}, opts)
-        })
-      })
-    )
-  }
 
   // == DOM Events ============================================================
 

--- a/addon/components/frost-list-content-container.js
+++ b/addon/components/frost-list-content-container.js
@@ -6,6 +6,8 @@ import Ember from 'ember'
 const {isNone} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
+import {PropTypes} from 'ember-prop-types'
+import {animate} from 'liquid-fire'
 
 import layout from '../templates/components/frost-list-content-container'
 
@@ -21,22 +23,53 @@ export default Component.extend({
   // == PropTypes =============================================================
 
   propTypes: {
+    itemKey: PropTypes.string
   },
 
   getDefaultProps () {
     return {
+      itemKey: null
     }
   },
 
   // == Computed Properties ===================================================
 
   @readOnly
+  @computed('itemKey')
+  _eachItemKey (itemKey) {
+    return itemKey || '@index'
+  },
+
+  @readOnly
+  @computed('itemKey')
+  _verticalCollectionItemKey (itemKey) {
+    return itemKey || '@identity'
+  },
+
+  @readOnly
   @computed('pagination')
   paged (pagination) {
     return !isNone(pagination)
-  }
+  },
 
   // == Functions =============================================================
+
+  _transition () {
+    this.transition(
+      this.use(function (opts = {duration: 300}) {
+        if (this.oldElement) {
+          this.oldElement.css('opacity', 1)
+        }
+        if (this.newElement) {
+          this.newElement.css('opacity', 0)
+        }
+
+        return animate(this.oldElement, {opacity: 0}, opts).then(() => {
+          return animate(this.newElement, {opacity: 1}, opts)
+        })
+      })
+    )
+  }
 
   // == DOM Events ============================================================
 

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -3,12 +3,11 @@
  */
 
 import Ember from 'ember'
-const {$, A, get, isEmpty, isNone, run} = Ember
+const {$, A, ObjectProxy, get, isEmpty, isNone, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {selection} from 'ember-frost-list'
 import {PropTypes} from 'ember-prop-types'
-import uuid from 'ember-simple-uuid'
 
 import layout from '../templates/components/frost-list'
 
@@ -96,43 +95,22 @@ export default Component.extend({
   // == Computed Properties ===================================================
 
   @readOnly
-  @computed('items.[]')
-  /**
-   * Add a unique id to every item to avoid rerendering on updates like selection and expansion.
-   * @param {Array} items a list of items
-   * @returns {Array} a list of items with unique ids
-   */
-  _itemsWithUniqueId (items) {
-    if (isEmpty(items)) {
-      return []
-    }
-
-    return items.map(item => {
-      return {
-        record: item,
-        uuid: uuid()
-      }
-    })
-  },
-
-  @readOnly
-  @computed('expandedItems.[]', '_itemsWithUniqueId.[]', 'selectedItems.[]', '_itemComparator')
+  @computed('expandedItems.[]', 'items.[]', 'selectedItems.[]', '_itemComparator')
   _items (expandedItems, items, selectedItems, _itemComparator) {
     if (isEmpty(items)) {
       return []
     }
 
-    return items.map(({uuid, record}) => {
-      return {
-        uuid,
-        record,
+    return items.map(item => {
+      return ObjectProxy.create({
+        content: item,
         states: {
           isExpanded: isEmpty(expandedItems) ? false : expandedItems.some(
-            selectedItem => _itemComparator(selectedItem, record)),
+            expandedItem => _itemComparator(expandedItem, item)),
           isSelected: isEmpty(selectedItems) ? false : selectedItems.some(
-            selectedItem => _itemComparator(selectedItem, record))
+            selectedItem => _itemComparator(selectedItem, item))
         }
-      }
+      })
     })
   },
 

--- a/addon/styles/_frost-list-content-container.scss
+++ b/addon/styles/_frost-list-content-container.scss
@@ -35,6 +35,14 @@
   }
 }
 
+.frost-list-content-container-animation {
+  height: 100%;
+
+  .liquid-child {
+    height: 100%;
+  }
+}
+
 // The scroll rail requires a padding offset, so a typical border-top/border-bottom
 // doesn't work (overflows the scroll gutter)
 // Offset rails https://github.com/noraesae/perfect-scrollbar/issues/508

--- a/addon/styles/_frost-list-content-container.scss
+++ b/addon/styles/_frost-list-content-container.scss
@@ -35,14 +35,6 @@
   }
 }
 
-.frost-list-content-container-animation {
-  height: 100%;
-
-  .liquid-child {
-    height: 100%;
-  }
-}
-
 // The scroll rail requires a padding offset, so a typical border-top/border-bottom
 // doesn't work (overflows the scroll gutter)
 // Offset rails https://github.com/noraesae/perfect-scrollbar/issues/508

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -10,34 +10,32 @@
     {{/each}}
   {{/frost-scroll}}
 {{else}}
-  {{#liquid-bind items class=(concat css '-animation') rules=_transition as |currentItems|}}
-    {{#vertical-collection
-      alwaysRemeasure=true
-      alwaysUseDefaultHeight=alwaysUseDefaultHeight
-      bufferSize=bufferSize
-      content=currentItems
-      defaultHeight=defaultHeight
-      firstReached=onLoadPrevious
-      lastReached=onLoadNext
-      scrollPosition=scrollTop
-      useContentProxy=false
-      key=_verticalCollectionItemKey
-      resizeDebounce=64
-      firstVisibleChanged=null
-      lastVisibleChanged=null
-      didMountCollection=null
-      idForFirstItem=null
-      renderFromLast=false
-      renderAllInitially=false
-      shouldRender=true
-      minimumMovement=15
-      containerSelector=null
-      containerHeight=null
-      as |model index|
-    }}
-      {{yield model index}}
-    {{else}}
-      {{yield to="inverse"}}
-    {{/vertical-collection}}
-  {{/liquid-bind}}
+  {{#vertical-collection
+    alwaysRemeasure=true
+    alwaysUseDefaultHeight=alwaysUseDefaultHeight
+    bufferSize=bufferSize
+    content=currentItems
+    defaultHeight=defaultHeight
+    firstReached=onLoadPrevious
+    lastReached=onLoadNext
+    scrollPosition=scrollTop
+    useContentProxy=false
+    key=_verticalCollectionItemKey
+    resizeDebounce=64
+    firstVisibleChanged=null
+    lastVisibleChanged=null
+    didMountCollection=null
+    idForFirstItem=null
+    renderFromLast=false
+    renderAllInitially=false
+    shouldRender=true
+    minimumMovement=15
+    containerSelector=null
+    containerHeight=null
+    as |model index|
+  }}
+    {{yield model index}}
+  {{else}}
+    {{yield to="inverse"}}
+  {{/vertical-collection}}
 {{/if}}

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -14,7 +14,7 @@
     alwaysRemeasure=true
     alwaysUseDefaultHeight=alwaysUseDefaultHeight
     bufferSize=bufferSize
-    content=currentItems
+    content=items
     defaultHeight=defaultHeight
     firstReached=onLoadPrevious
     lastReached=onLoadNext

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -3,41 +3,41 @@
   {{#frost-scroll
     hook=(concat hookPrefix '-scroll')
   }}
-    {{#each items key='uuid' as |model index|}}
+    {{#each items key=_eachItemKey as |model index|}}
       {{yield model index}}
     {{else}}
       {{yield to="inverse"}}
     {{/each}}
   {{/frost-scroll}}
 {{else}}
-  {{#vertical-collection
-    alwaysRemeasure=true
-    alwaysUseDefaultHeight=alwaysUseDefaultHeight
-    bufferSize=bufferSize
-    content=items
-    defaultHeight=defaultHeight
-    firstReached=onLoadPrevious
-    lastReached=onLoadNext
-    scrollPosition=scrollTop
-    useContentProxy=false
-
-    key='@identity'
-    resizeDebounce=64
-    firstVisibleChanged=null
-    lastVisibleChanged=null
-    didMountCollection=null
-    idForFirstItem=null
-    renderFromLast=false
-    renderAllInitially=false
-    shouldRender=true
-    minimumMovement=15
-    containerSelector=null
-    containerHeight=null
-
-    as |model index|
-  }}
-    {{yield model index}}
-  {{else}}
-    {{yield to="inverse"}}
-  {{/vertical-collection}}
+  {{#liquid-bind items class=(concat css '-animation') rules=_transition as |currentItems|}}
+    {{#vertical-collection
+      alwaysRemeasure=true
+      alwaysUseDefaultHeight=alwaysUseDefaultHeight
+      bufferSize=bufferSize
+      content=currentItems
+      defaultHeight=defaultHeight
+      firstReached=onLoadPrevious
+      lastReached=onLoadNext
+      scrollPosition=scrollTop
+      useContentProxy=false
+      key=_verticalCollectionItemKey
+      resizeDebounce=64
+      firstVisibleChanged=null
+      lastVisibleChanged=null
+      didMountCollection=null
+      idForFirstItem=null
+      renderFromLast=false
+      renderAllInitially=false
+      shouldRender=true
+      minimumMovement=15
+      containerSelector=null
+      containerHeight=null
+      as |model index|
+    }}
+      {{yield model index}}
+    {{else}}
+      {{yield to="inverse"}}
+    {{/vertical-collection}}
+  {{/liquid-bind}}
 {{/if}}

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -35,6 +35,7 @@
   defaultHeight=defaultHeight
   hook=(concat hookPrefix '-contentContainer')
   items=_items
+  itemKey=itemKey
   pagination=pagination
   scrollTop=scrollTop
   onLoadNext=onLoadNext
@@ -54,7 +55,7 @@
         {{frost-list-item-expansion
           hook=(concat hookPrefix '-expansion')
           hookQualifiers=(hash index=index)
-          model=model.record
+          model=model.content
           isExpanded=model.states.isExpanded
           onExpand=(action '_expand')
         }}
@@ -64,7 +65,7 @@
         {{frost-list-item-selection
           hook=(concat hookPrefix '-selection')
           hookQualifiers=(hash index=index)
-          model=model.record
+          model=model.content
           isSelected=model.states.isSelected
           onSelect=(action '_select')
         }}
@@ -73,7 +74,7 @@
       {{component item
         hook=(concat hookPrefix '-item')
         hookQualifiers=(hash index=index)
-        model=model.record
+        model=model.content
         isExpanded=model.states.isExpanded
         isSelected=model.states.isSelected
         onSelect=(action '_select')
@@ -85,7 +86,7 @@
         {{component itemExpansion
           hook=(concat hookPrefix '-item-expansion')
           hookQualifiers=(hash index=index)
-          model=model.record
+          model=model.content
           isExpanded=model.states.isExpanded
           isSelected=model.states.isSelected
           onSelect=(action '_select')

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "name": "frost-list"
   },
   "pr-bumper": {
-    "coverage": 95.8
+    "coverage": 95.0
   }
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- Exposed `itemKey` as a configurable property.  List records with a matching `itemKey` will update instead of fully re-rendering when the record changes.
