### PR TITLE
Bugfix: Modified specific multi-select to also work with non-mac systems

### DIFF
--- a/addon/components/frost-list-item.js
+++ b/addon/components/frost-list-item.js
@@ -43,7 +43,7 @@ export default Component.extend({
 
   click (event) {
     // Acceptable event modifiers
-    const isSpecificSelect = (new window.UAParser()).getOS() === 'Mac OS' ? event.ctrlKey : event.metaKey // TODO Move instance to a service
+    const isSpecificSelect = (new window.UAParser()).getOS().name === 'Mac OS' ? event.metaKey : event.ctrlKey // TODO Move instance to a service
     const isRangeSelect = event.shiftKey
 
     // Only process simple clicks or clicks with the acceptable modifiers


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- **Modified** specific multi-select to also work with non-mac systems.
	modified:   addon/components/frost-list-item.js
