### PR TITLE
WIP List item type support

### DIFF
--- a/addon/components/frost-list-item-content.js
+++ b/addon/components/frost-list-item-content.js
@@ -1,0 +1,37 @@
+import {Component} from 'ember-frost-core'
+import {PropTypes} from 'ember-prop-types'
+
+import layout from '../templates/components/frost-list-item-content'
+
+export default Component.extend({
+
+  // == Dependencies ==========================================================
+
+  // == Keyword Properties ====================================================
+  layout,
+
+  // == PropTypes =============================================================
+
+  propTypes: {
+    // Options - required
+    model: PropTypes.EmberObject.isRequired,
+    index: PropTypes.number.isRequired,
+    onSelectionChange: PropTypes.func.isRequired,
+    onExpand: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
+
+    // Options - sub-components
+    item: PropTypes.EmberComponent.isRequired,
+    itemExpansion: PropTypes.EmberComponent
+  }
+
+  // == Computed Properties ===================================================
+
+  // == Functions =============================================================
+
+  // == DOM Events ============================================================
+
+  // == Lifecycle Hooks =======================================================
+
+  // == Actions ===============================================================
+})

--- a/addon/components/frost-list-item-content.js
+++ b/addon/components/frost-list-item-content.js
@@ -1,3 +1,6 @@
+import Ember from 'ember'
+const {get, isPresent} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {PropTypes} from 'ember-prop-types'
 
@@ -16,16 +19,78 @@ export default Component.extend({
     // Options - required
     model: PropTypes.EmberObject.isRequired,
     index: PropTypes.number.isRequired,
-    onSelectionChange: PropTypes.func.isRequired,
     onExpand: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
+
+    // Options - general
+    onSelectionChange: PropTypes.func,
+    itemTypes: PropTypes.object,
+    isAnyCustomItemExpansion: PropTypes.bool,
 
     // Options - sub-components
     item: PropTypes.EmberComponent.isRequired,
     itemExpansion: PropTypes.EmberComponent
-  }
+  },
+
+  getDefaultProps () {
+    return {
+      isAnyCustomItemExpansion: false
+    }
+  },
 
   // == Computed Properties ===================================================
+
+  @readOnly
+  @computed('model', 'itemTypes')
+  typedItemComponent (model, itemTypes) {
+    if (isPresent(model) && isPresent(itemTypes)) {
+      const type = model.get('type')
+
+      if (type in itemTypes) {
+        const itemType = get(itemTypes, type)
+        const item = get(itemType, 'item')
+
+        return item
+      }
+    }
+  },
+
+  @readOnly
+  @computed('model', 'itemTypes')
+  typedItemExpansionComponent (model, itemTypes) {
+    if (isPresent(model) && isPresent(itemTypes)) {
+      const type = model.get('type')
+
+      if (type in itemTypes) {
+        const itemType = get(itemTypes, type)
+        const itemExpansion = get(itemType, 'itemExpansion')
+
+        return itemExpansion
+      }
+    }
+  },
+
+  @readOnly
+  @computed('typedItemComponent', 'typedItemExpansionComponent')
+  isTypedItemWithExpansion (typedItemComponent, typedItemExpansionComponent) {
+    return typedItemComponent && typedItemExpansionComponent
+  },
+
+  @readOnly
+  @computed('typedItemComponent', 'typedItemExpansionComponent')
+  isTypedItemWithoutExpansion (typedItemComponent, typedItemExpansionComponent) {
+    return typedItemComponent && !typedItemExpansionComponent
+  },
+
+  @readOnly
+  @computed('typedItemComponent', 'item')
+  itemComponent (typedItemComponent, item) {
+    if (typedItemComponent) {
+      return typedItemComponent
+    }
+
+    return item
+  }
 
   // == Functions =============================================================
 

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -3,7 +3,7 @@
  */
 
 import Ember from 'ember'
-const {$, A, ObjectProxy, get, isEmpty, isNone, run} = Ember
+const {$, A, ObjectProxy, get, isEmpty, isNone, isPresent, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {selection} from 'ember-frost-list'
@@ -43,6 +43,7 @@ export default Component.extend({
     ])),
     onSelectionChange: PropTypes.func,
     itemKey: PropTypes.string,
+    itemTypes: PropTypes.object,
 
     // Options - sub-components
     pagination: PropTypes.EmberComponent,
@@ -112,6 +113,23 @@ export default Component.extend({
         }
       })
     })
+  },
+
+  @readOnly
+  @computed('itemTypes')
+  isAnyCustomItemExpansion (itemTypes) {
+    if (isPresent(itemTypes)) {
+      for (var itemType in itemTypes) {
+        const type = get(itemTypes, itemType)
+        const itemExpansion = get(type, 'itemExpansion')
+
+        if (isPresent(itemExpansion)) {
+          return true
+        }
+      }
+    }
+
+    return false
   },
 
   // == Functions =============================================================

--- a/addon/templates/components/frost-list-item-content.hbs
+++ b/addon/templates/components/frost-list-item-content.hbs
@@ -40,7 +40,7 @@
   {{#if model.states.isExpanded}}
     <div class='frost-list-item-container-expansion'>
       {{#if isTypedItemWithExpansion}}
-        {{component typedItemComponent
+        {{component typedItemExpansionComponent
           hook=(concat hookPrefix '-item')
           hookQualifiers=(hash index=index)
           model=model.content

--- a/addon/templates/components/frost-list-item-content.hbs
+++ b/addon/templates/components/frost-list-item-content.hbs
@@ -41,7 +41,7 @@
     <div class='frost-list-item-container-expansion'>
       {{#if isTypedItemWithExpansion}}
         {{component typedItemExpansionComponent
-          hook=(concat hookPrefix '-item')
+          hook=(concat hookPrefix '-itemExpansion')
           hookQualifiers=(hash index=index)
           model=model.content
           isExpanded=model.states.isExpanded
@@ -52,7 +52,7 @@
         {{!-- Don't render default expansion template --}}
       {{else}}
         {{component itemExpansion
-          hook=(concat hookPrefix '-item')
+          hook=(concat hookPrefix '-itemExpansion')
           hookQualifiers=(hash index=index)
           model=model.content
           isExpanded=model.states.isExpanded

--- a/addon/templates/components/frost-list-item-content.hbs
+++ b/addon/templates/components/frost-list-item-content.hbs
@@ -1,0 +1,52 @@
+<div class={{concat
+    'frost-list-item-container'
+    (if (eq index 0) ' first')
+    (if (eq index (sub _items.length 1)) ' last')
+    (if model.states.isSelected ' is-selected')
+  }}
+  data-test={{hook (concat hook '-item-container') index=index }}
+>
+  <div class='frost-list-item-container-base'>
+    {{#if itemExpansion}}
+      {{frost-list-item-expansion
+        hook=(concat hookPrefix '-expansion')
+        hookQualifiers=(hash index=index)
+        model=model.content
+        isExpanded=model.states.isExpanded
+        onExpand=onExpand
+      }}
+    {{/if}}
+
+    {{#if onSelectionChange}}
+      {{frost-list-item-selection
+        hook=(concat hookPrefix '-selection')
+        hookQualifiers=(hash index=index)
+        model=model.content
+        isSelected=model.states.isSelected
+        onSelect=onSelect
+      }}
+    {{/if}}
+
+    {{component item
+      hook=(concat hookPrefix '-item')
+      hookQualifiers=(hash index=index)
+      model=model.content
+      isExpanded=model.states.isExpanded
+      isSelected=model.states.isSelected
+      onSelect=onSelect
+    }}
+  </div>
+
+  {{#if model.states.isExpanded}}
+    <div class='frost-list-item-container-expansion'>
+      {{component itemExpansion
+        hook=(concat hookPrefix '-item')
+        hookQualifiers=(hash index=index)
+        model=model.content
+        isExpanded=model.states.isExpanded
+        isSelected=model.states.isSelected
+        onSelect=onSelect
+      }}
+    </div>
+  {{/if}}
+</div>

--- a/addon/templates/components/frost-list-item-content.hbs
+++ b/addon/templates/components/frost-list-item-content.hbs
@@ -7,7 +7,7 @@
   data-test={{hook (concat hook '-item-container') index=index }}
 >
   <div class='frost-list-item-container-base'>
-    {{#if itemExpansion}}
+    {{#if (and (or itemExpansion isTypedItemWithExpansion) (not isTypedItemWithoutExpansion))}}
       {{frost-list-item-expansion
         hook=(concat hookPrefix '-expansion')
         hookQualifiers=(hash index=index)
@@ -27,7 +27,7 @@
       }}
     {{/if}}
 
-    {{component item
+    {{component itemComponent
       hook=(concat hookPrefix '-item')
       hookQualifiers=(hash index=index)
       model=model.content
@@ -39,14 +39,27 @@
 
   {{#if model.states.isExpanded}}
     <div class='frost-list-item-container-expansion'>
-      {{component itemExpansion
-        hook=(concat hookPrefix '-item')
-        hookQualifiers=(hash index=index)
-        model=model.content
-        isExpanded=model.states.isExpanded
-        isSelected=model.states.isSelected
-        onSelect=onSelect
-      }}
+      {{#if isTypedItemWithExpansion}}
+        {{component typedItemComponent
+          hook=(concat hookPrefix '-item')
+          hookQualifiers=(hash index=index)
+          model=model.content
+          isExpanded=model.states.isExpanded
+          isSelected=model.states.isSelected
+          onSelect=onSelect
+        }}
+      {{else if isTypedItemWithoutExpansion}}
+        {{!-- Don't render default expansion template --}}
+      {{else}}
+        {{component itemExpansion
+          hook=(concat hookPrefix '-item')
+          hookQualifiers=(hash index=index)
+          model=model.content
+          isExpanded=model.states.isExpanded
+          isSelected=model.states.isSelected
+          onSelect=onSelect
+        }}
+      {{/if}}
     </div>
   {{/if}}
 </div>

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -14,11 +14,11 @@
       }}
     {{/if}}
 
-    {{#if (and pagination itemExpansion)}}
+    {{#if (and pagination (or itemExpansion isAnyCustomItemExpansion))}}
       <div class='frost-list-header-divider'></div>
     {{/if}}
 
-    {{#if itemExpansion}}
+    {{#if (or itemExpansion isAnyCustomItemExpansion)}}
       {{frost-list-expansion
         hook=(concat hookPrefix '-expansion')
         onCollapseAll=(action '_collapseAll')
@@ -46,6 +46,7 @@
     hook=(concat hookPrefix '-itemContent')
     model=model
     index=index
+    itemTypes=itemTypes
     item=item
     itemExpansion=itemExpansion
     onSelectionChange=onSelectionChange

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -44,6 +44,7 @@
 }}
   {{frost-list-item-content
     hook=(concat hookPrefix '-itemContent')
+    hookQualifiers=(hash index=index)
     model=model
     index=index
     itemTypes=itemTypes

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -42,58 +42,16 @@
   onLoadPrevious=onLoadPrevious
   as |model index|
 }}
-  <div class={{concat
-      'frost-list-item-container'
-      (if (eq index 0) ' first')
-      (if (eq index (sub _items.length 1)) ' last')
-      (if model.states.isSelected ' is-selected')
-    }}
-    data-test={{hook (concat hook '-item-container') index=index }}
-  >
-    <div class='frost-list-item-container-base'>
-      {{#if itemExpansion}}
-        {{frost-list-item-expansion
-          hook=(concat hookPrefix '-expansion')
-          hookQualifiers=(hash index=index)
-          model=model.content
-          isExpanded=model.states.isExpanded
-          onExpand=(action '_expand')
-        }}
-      {{/if}}
-
-      {{#if onSelectionChange}}
-        {{frost-list-item-selection
-          hook=(concat hookPrefix '-selection')
-          hookQualifiers=(hash index=index)
-          model=model.content
-          isSelected=model.states.isSelected
-          onSelect=(action '_select')
-        }}
-      {{/if}}
-
-      {{component item
-        hook=(concat hookPrefix '-item')
-        hookQualifiers=(hash index=index)
-        model=model.content
-        isExpanded=model.states.isExpanded
-        isSelected=model.states.isSelected
-        onSelect=(action '_select')
-      }}
-    </div>
-
-    {{#if model.states.isExpanded}}
-      <div class='frost-list-item-container-expansion'>
-        {{component itemExpansion
-          hook=(concat hookPrefix '-item-expansion')
-          hookQualifiers=(hash index=index)
-          model=model.content
-          isExpanded=model.states.isExpanded
-          isSelected=model.states.isSelected
-          onSelect=(action '_select')
-        }}
-      </div>
-    {{/if}}
-  </div>
+  {{frost-list-item-content
+    hook=(concat hookPrefix '-itemContent')
+    model=model
+    index=index
+    item=item
+    itemExpansion=itemExpansion
+    onSelectionChange=onSelectionChange
+    onExpand=(action '_expand')
+    onSelect=(action '_select')
+  }}
 {{else}}
   {{yield to="inverse"}}
 {{/frost-list-content-container}}

--- a/app/components/frost-list-item-content.js
+++ b/app/components/frost-list-item-content.js
@@ -1,0 +1,1 @@
+export {default} from 'ember-frost-list/components/frost-list-item-content'

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -75,7 +75,7 @@ describe(test.label, function () {
     })
 
     it('creates one list item', function () {
-      expect($hook('myList-item')).to.have.length(1)
+      expect($hook('myList-itemContent-item')).to.have.length(1)
     })
   })
 
@@ -188,7 +188,7 @@ describe(test.label, function () {
     })
 
     it('should render the "frost-list-item-expansion" component', function () {
-      expect($hook('myList-expansion', {index: 0})).to.have.length(1)
+      expect($hook('myList-itemContent-expansion', {index: 0})).to.have.length(1)
     })
 
     describe('when "model.isExpanded" is set to "true"', function () {
@@ -235,7 +235,7 @@ describe(test.label, function () {
     })
 
     it('should render the "frost-list-item-selection" for checkbox selection', function () {
-      expect($hook('myList-selection')).to.have.length(1)
+      expect($hook('myList-itemContent-selection')).to.have.length(1)
     })
   })
 
@@ -261,11 +261,11 @@ describe(test.label, function () {
     })
 
     it('item 0 is selected', function () {
-      expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+      expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
     })
 
     it('item 1 is not selected', function () {
-      expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+      expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
     })
 
     it('selectedItems length to be 1', function () {
@@ -301,10 +301,10 @@ describe(test.label, function () {
     })
 
     it('item 0 is selected', function () {
-      expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+      expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
     })
     it('item 1 is not selected', function () {
-      expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+      expect($hook('myList-itemContent-container', {index: 1}).hasClass('is-selected')).to.eql(false)
     })
 
     it('selectedItems length to be 1', function () {
@@ -344,19 +344,19 @@ describe(test.label, function () {
       describe('Supports basic click', function () {
         describe('Selecting item 0', function () {
           beforeEach(function () {
-            $hook('myList-item', {index: 0}).click()
+            $hook('myList-itemContent-item', {index: 0}).click()
             return wait()
           })
 
           it('item 0 is selected', function () {
             return wait().then(() => {
-              expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
             })
           })
 
           it('item 1 is not selected', function () {
             return wait().then(() => {
-              expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
             })
           })
 
@@ -368,16 +368,16 @@ describe(test.label, function () {
 
           describe('Selecting previous selected item', function () {
             beforeEach(function () {
-              $hook('myList-item', {index: 0}).click()
+              $hook('myList-itemContent-item', {index: 0}).click()
               return wait()
             })
 
             it('item 0 is not selected', function () {
-              expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
             })
 
             it('item 1 is not selected', function () {
-              expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
             })
 
             it('selectedItems length to be 0', function () {
@@ -388,18 +388,18 @@ describe(test.label, function () {
 
         describe('All items selected, then select item 0', function () {
           beforeEach(function () {
-            $hook('myList-selection', {index: 0}).click()
-            $hook('myList-selection', {index: 1}).click()
-            $hook('myList-item', {index: 0}).click()
+            $hook('myList-itemContent-selection', {index: 0}).click()
+            $hook('myList-itemContent-selection', {index: 1}).click()
+            $hook('myList-itemContent-item', {index: 0}).click()
             return wait()
           })
 
           it('item 0 is selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 1 is not selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
           })
 
           it('selectedItems length to be 1', function () {
@@ -411,15 +411,15 @@ describe(test.label, function () {
       describe('Supports specific click', function () {
         describe('Selecting item 0', function () {
           beforeEach(function () {
-            $hook('myList-selection', {index: 0}).click()
+            $hook('myList-itemContent-selection', {index: 0}).click()
             return wait()
           })
 
           it('item 0 is selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
           })
           it('item 1 is not selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
           })
 
           it('selectedItems length to be 1', function () {
@@ -428,16 +428,16 @@ describe(test.label, function () {
 
           describe('Unselecting item 1', function () {
             beforeEach(function () {
-              $hook('myList-selection', {index: 0}).click()
+              $hook('myList-itemContent-selection', {index: 0}).click()
               return wait()
             })
 
             it('item 0 is not selected', function () {
-              expect($($hook('myList-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
+              expect($($hook('myList-itemContent-item-container', {index: 0})).hasClass('is-selected')).to.eql(false)
             })
 
             it('item 1 is not selected', function () {
-              expect($($hook('myList-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
+              expect($($hook('myList-itemContent-item-container', {index: 1})).hasClass('is-selected')).to.eql(false)
             })
 
             it('selectedItems length to be 0', function () {
@@ -448,17 +448,17 @@ describe(test.label, function () {
 
         describe('Selecting every item', function () {
           beforeEach(function () {
-            $hook('myList-selection', {index: 0}).click()
-            $hook('myList-selection', {index: 1}).click()
+            $hook('myList-itemContent-selection', {index: 0}).click()
+            $hook('myList-itemContent-selection', {index: 1}).click()
             return wait()
           })
 
           it('item 0 is selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 1 is selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
           })
 
           it('selectedItems length to be 2', function () {
@@ -467,17 +467,17 @@ describe(test.label, function () {
 
           describe('Unselect each item', function () {
             beforeEach(function () {
-              $hook('myList-selection', {index: 0}).click()
-              $hook('myList-selection', {index: 1}).click()
+              $hook('myList-itemContent-selection', {index: 0}).click()
+              $hook('myList-itemContent-selection', {index: 1}).click()
               return wait()
             })
 
             it('item 0 is not selected', function () {
-              expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
             })
 
             it('item 1 is not selected', function () {
-              expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
             })
 
             it('selectedItems length to be 0', function () {
@@ -508,37 +508,37 @@ describe(test.label, function () {
             clickEvent.shiftKey = true
             const clickEvent2 = $.Event('click')
             clickEvent2.shiftKey = true
-            $hook('myList-item', {index: 1}).trigger(clickEvent)
-            $hook('myList-item', {index: 5}).trigger(clickEvent2)
+            $hook('myList-itemContent-item', {index: 1}).trigger(clickEvent)
+            $hook('myList-itemContent-item', {index: 5}).trigger(clickEvent2)
             return wait()
           })
 
           it('item 0 is not selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 1 is selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 2 is selected', function () {
-            expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 3 is selected', function () {
-            expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 4 is selected', function () {
-            expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 5 is selected', function () {
-            expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 6 is not selected', function () {
-            expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
           })
 
           it('selectedItems length to be 5', function () {
@@ -550,36 +550,36 @@ describe(test.label, function () {
           beforeEach(function () {
             const clickEvent = $.Event('click')
             clickEvent.shiftKey = true
-            $hook('myList-item', {index: 1}).trigger(clickEvent)
+            $hook('myList-itemContent-item', {index: 1}).trigger(clickEvent)
             return wait()
           })
 
           it('item 0 is not selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 1 is selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 2 is not selected', function () {
-            expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 3 is not selected', function () {
-            expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 4 is not selected', function () {
-            expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 5 is not selected', function () {
-            expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 6 is not selected', function () {
-            expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
           })
 
           it('selectedItems length to be 1', function () {
@@ -590,36 +590,36 @@ describe(test.label, function () {
             beforeEach(function () {
               const clickEvent = $.Event('click')
               clickEvent.shiftKey = true
-              $hook('myList-item', {index: 3}).trigger(clickEvent)
+              $hook('myList-itemContent-item', {index: 3}).trigger(clickEvent)
               return wait()
             })
 
             it('item 0 is not selected', function () {
-              expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
             })
 
             it('item 1 is selected', function () {
-              expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 2 is selected', function () {
-              expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 3 is selected', function () {
-              expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 4 is not selected', function () {
-              expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
             })
 
             it('item 5 is not selected', function () {
-              expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
             })
 
             it('item 6 is not selected', function () {
-              expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+              expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
             })
 
             it('selectedItems length to be 3', function () {
@@ -630,36 +630,36 @@ describe(test.label, function () {
               beforeEach(function () {
                 const clickEvent = $.Event('click')
                 clickEvent.shiftKey = true
-                $hook('myList-item', {index: 5}).trigger(clickEvent)
+                $hook('myList-itemContent-item', {index: 5}).trigger(clickEvent)
                 return wait()
               })
 
               it('item 0 is not selected', function () {
-                expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+                expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
               })
 
               it('item 1 is selected', function () {
-                expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+                expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
               })
 
               it('item 2 is selected', function () {
-                expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+                expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
               })
 
               it('item 3 is selected', function () {
-                expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
+                expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
               })
 
               it('item 4 is selected', function () {
-                expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
+                expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
               })
 
               it('item 5 is selected', function () {
-                expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
+                expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
               })
 
               it('item 6 is not selected', function () {
-                expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+                expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
               })
 
               it('selectedItems length to be 5', function () {
@@ -670,36 +670,36 @@ describe(test.label, function () {
                 beforeEach(function () {
                   const clickEvent = $.Event('click')
                   clickEvent.shiftKey = true
-                  $hook('myList-item', {index: 1}).trigger(clickEvent)
+                  $hook('myList-itemContent-item', {index: 1}).trigger(clickEvent)
                   return wait()
                 })
 
                 it('item 0 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 1 is selected', function () {
-                  expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+                  expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
                 })
 
                 it('item 2 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 3 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 4 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 5 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 6 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('selectedItems length to be 1', function () {
@@ -711,36 +711,36 @@ describe(test.label, function () {
                 beforeEach(function () {
                   const clickEvent = $.Event('click')
                   clickEvent.shiftKey = true
-                  $hook('myList-item', {index: 0}).trigger(clickEvent)
+                  $hook('myList-itemContent-item', {index: 0}).trigger(clickEvent)
                   return wait()
                 })
 
                 it('item 0 is selected', function () {
-                  expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+                  expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
                 })
 
                 it('item 1 is selected', function () {
-                  expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+                  expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
                 })
 
                 it('item 2 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 3 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 4 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 5 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('item 6 is not selected', function () {
-                  expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+                  expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
                 })
 
                 it('selectedItems length to be 2', function () {
@@ -821,21 +821,21 @@ describe(test.label, function () {
           clickEvent.shiftKey = true
           const clickEvent2 = $.Event('click')
           clickEvent2.shiftKey = true
-          $hook('myList-item', {index: 0}).trigger(clickEvent)
-          $hook('myList-item', {index: 2}).trigger(clickEvent2)
+          $hook('myList-itemContent-item', {index: 0}).trigger(clickEvent)
+          $hook('myList-itemContent-item', {index: 2}).trigger(clickEvent2)
           return wait()
         })
 
         it('item 0 is selected', function () {
-          expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 1 is selected', function () {
-          expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 2 is selected', function () {
-          expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
         })
 
         it('selectedItems length to be 3', function () {
@@ -849,15 +849,15 @@ describe(test.label, function () {
           })
 
           it('item 0 is not selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 1 is not selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(false)
           })
 
           it('item 2 is not selected', function () {
-            expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
+            expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
           })
 
           it('selectedItems length to be 3', function () {
@@ -874,20 +874,20 @@ describe(test.label, function () {
               clickEvent.shiftKey = true
               const clickEvent2 = $.Event('click')
               clickEvent2.shiftKey = true
-              $hook('myList-item', {index: 0}).trigger(clickEvent)
-              $hook('myList-item', {index: 2}).trigger(clickEvent2)
+              $hook('myList-itemContent-item', {index: 0}).trigger(clickEvent)
+              $hook('myList-itemContent-item', {index: 2}).trigger(clickEvent2)
               return wait()
             })
             it('item 0 is selected', function () {
-              expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 1 is selected', function () {
-              expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 2 is selected', function () {
-              expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
             })
 
             it('selectedItems length to be 6', function () {
@@ -899,20 +899,20 @@ describe(test.label, function () {
 
       describe('When using specific select on item 2', function () {
         beforeEach(function () {
-          $hook('myList-selection', {index: 1}).click()
+          $hook('myList-itemContent-selection', {index: 1}).click()
           return wait()
         })
 
         it('item 0 is not selected', function () {
-          expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+          expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
         })
 
         it('item 1 is selected', function () {
-          expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 2 is not selected', function () {
-          expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
+          expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(false)
         })
 
         it('selectedItems length to be 1', function () {
@@ -927,22 +927,22 @@ describe(test.label, function () {
               clickEvent.shiftKey = true
               const clickEvent2 = $.Event('click')
               clickEvent2.shiftKey = true
-              $hook('myList-item', {index: 0}).trigger(clickEvent)
-              $hook('myList-item', {index: 2}).trigger(clickEvent2)
+              $hook('myList-itemContent-item', {index: 0}).trigger(clickEvent)
+              $hook('myList-itemContent-item', {index: 2}).trigger(clickEvent2)
               return wait()
             })
           })
 
           it('item 0 is selected', function () {
-            expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 1 is selected', function () {
-            expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
           })
 
           it('item 2 is selected', function () {
-            expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+            expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
           })
 
           it('selectedItems length to be 4', function () {
@@ -957,22 +957,22 @@ describe(test.label, function () {
                 clickEvent.shiftKey = true
                 const clickEvent2 = $.Event('click')
                 clickEvent2.shiftKey = true
-                $hook('myList-item', {index: 0}).trigger(clickEvent)
-                $hook('myList-item', {index: 2}).trigger(clickEvent2)
+                $hook('myList-itemContent-item', {index: 0}).trigger(clickEvent)
+                $hook('myList-itemContent-item', {index: 2}).trigger(clickEvent2)
                 return wait()
               })
             })
 
             it('item 0 is selected', function () {
-              expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 1 is selected', function () {
-              expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
             })
 
             it('item 2 is selected', function () {
-              expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+              expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
             })
 
             it('selectedItems length to be 6', function () {
@@ -1023,37 +1023,37 @@ describe(test.label, function () {
           clickEvent.shiftKey = true
           const clickEvent2 = $.Event('click')
           clickEvent2.shiftKey = true
-          $hook('myList-item', {index: 1}).trigger(clickEvent)
-          $hook('myList-item', {index: 5}).trigger(clickEvent2)
+          $hook('myList-itemContent-item', {index: 1}).trigger(clickEvent)
+          $hook('myList-itemContent-item', {index: 5}).trigger(clickEvent2)
           return wait()
         })
 
         it('item 0 is not selected', function () {
-          expect($hook('myList-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
+          expect($hook('myList-itemContent-item-container', {index: 0}).hasClass('is-selected')).to.eql(false)
         })
 
         it('item 1 is selected', function () {
-          expect($hook('myList-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 1}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 2 is selected', function () {
-          expect($hook('myList-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 2}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 3 is selected', function () {
-          expect($hook('myList-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 3}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 4 is selected', function () {
-          expect($hook('myList-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 4}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 5 is selected', function () {
-          expect($hook('myList-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
+          expect($hook('myList-itemContent-item-container', {index: 5}).hasClass('is-selected')).to.eql(true)
         })
 
         it('item 6 is not selected', function () {
-          expect($hook('myList-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
+          expect($hook('myList-itemContent-item-container', {index: 6}).hasClass('is-selected')).to.eql(false)
         })
 
         it('selectedItems length to be 5', function () {
@@ -1099,21 +1099,21 @@ describe(test.label, function () {
 
     describe('clicking item 0 expansion button', function () {
       beforeEach(function () {
-        $hook('myList-expansion', {index: 0}).click()
+        $hook('myList-itemContent-expansion', {index: 0}).click()
         return wait()
       })
 
       it('item 0 is expanded', function () {
-        expect($hook('myList-item-expansion', {index: 0})).to.have.length(1)
+        expect($hook('myList-itemContent-itemExpansion', {index: 0})).to.have.length(1)
       })
 
       describe('clicking item 0 expansion button', function () {
         beforeEach(function () {
-          $hook('myList-expansion', {index: 0}).click()
+          $hook('myList-itemContent-expansion', {index: 0}).click()
           return wait()
         })
         it('item 0 is not expanded', function () {
-          expect($hook('myList-item-expansion', {index: 0})).to.have.length(0)
+          expect($hook('myList-itemContent-itemExpansion', {index: 0})).to.have.length(0)
         })
       })
     })
@@ -1125,11 +1125,11 @@ describe(test.label, function () {
       })
 
       it('item 0 is expanded', function () {
-        expect($hook('myList-item-expansion', {index: 0})).to.have.length(1)
+        expect($hook('myList-itemContent-itemExpansion', {index: 0})).to.have.length(1)
       })
 
       it('item 1 is expanded', function () {
-        expect($hook('myList-item-expansion', {index: 1})).to.have.length(1)
+        expect($hook('myList-itemContent-itemExpansion', {index: 1})).to.have.length(1)
       })
     })
   })


### PR DESCRIPTION
**This pull request is a work in progress, and should not be merged yet.**

The following work has been completed:
- [x] Extract list item content into new component
- [x] Add support for rendering different list-item and list-item-expansion components based on a set of types

The following work is still to be completed:
- [ ] Add support for list-items to have different controls depending on their type
- [ ] Add test coverage for new list-item-content-component
- [ ] Fix alignment of items when mixed between with expansion and without expansion

### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [x] #major# - incompatible API change

# CHANGELOG

* Added a new frost-list-item-content component
* Added support for rendering different list-item and list-item-expansion components based on a set of types
* Changed hook from `-item` to `-itemContent-item` for list-item component
* Changed hook from `-expansion` to `-itemContent-expansion` for frost-list-item-expansion component
* Changed hook from `-selection` to `-itemContent-selection` for frost-list-item-selection component
* Changed hook from `-item-container` to `-itemContent-item-container` for frost-list-item-container DOM element
* Changed hook from `-item` to `-itemExpansion` for list-item-expansion component