### PR TITLE
Add size interface to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Sub Attribute`    | `properties`         | `array`          |       | Array of sortable attributes. eg. [{"label: "foo", "value": "bar"}], This is an attribute on frost-sort component.|
 | `Sub Attribute`    | `onSort`             | `action closure` |       | callback functions user provided to handle sorting.  This is an attribute on frost-sort component.|
 | `Attribute`        | `itemKey`            | `string`         |       | Optional: With itemKey set, item.get(itemKey) will be used for comparision, Else the default item === item comparison used. |
-| `Attribute`        | `size`               | `string`         |       | Optional: Size can take either "small" or "medium". With size set to "small", list will provide a compressed list item view. This attribute gets ignored when defaultHeight is provided. |
+| `Attribute`        | `size`               | `string`         |       | Optional: Defaults to "medium", and can take either "small" or "medium". With size set to "small", list will provide a compressed list item view. This attribute gets ignored when defaultHeight is provided. |
 ### Infinite scroll
 
 | parameters type | Attribute | Type | Description |

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Sub Attribute`    | `properties`         | `array`          |       | Array of sortable attributes. eg. [{"label: "foo", "value": "bar"}], This is an attribute on frost-sort component.|
 | `Sub Attribute`    | `onSort`             | `action closure` |       | callback functions user provided to handle sorting.  This is an attribute on frost-sort component.|
 | `Attribute`        | `itemKey`            | `string`         |       | Optional: With itemKey set, item.get(itemKey) will be used for comparision, Else the default item === item comparison used. |
-
-
+| `Attribute`        | `size`               | `string`         |       | Optional: Size can take either "small" or "medium". With size set to "small", list will provide a compressed list item view. This attribute gets ignored when defaultHeight is provided. |
 ### Infinite scroll
 
 | parameters type | Attribute | Type | Description |

--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Attribute`        | `itemExpansionDefinitions` | `hash`     |       | Optional: A set of components that are to be used in the list as the `itemExpansion` component. Note that this had to be used in conjunction with `componentKeyNamesForTypes` |
 
 
->>>>>>> cc90c3107e5d88e81b88119af521d6e4775e8aac
 ### Infinite scroll
 
 | parameters type | Attribute | Type | Description |

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -119,18 +119,25 @@ export default Component.extend({
   @readOnly
   @computed('defaultHeight', 'size')
   listRowHeight (defaultHeight, size) {
+    let listRowHeight
+
     if (isPresent(defaultHeight)) {
-      return defaultHeight
+      listRowHeight = defaultHeight
+    } else {
+      switch (size) {
+        case 'medium':
+          listRowHeight = 50
+          break
+        case 'small':
+          listRowHeight = 30
+          break
+        default:
+          listRowHeight = 50
+          break
+      }
     }
 
-    switch (size) {
-      case 'medium':
-        return 50
-      case 'small':
-        return 30
-      default:
-        return 50
-    }
+    return listRowHeight
   },
 
   @readOnly

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -3,7 +3,7 @@
  */
 
 import Ember from 'ember'
-const {$, A, ObjectProxy, get, isEmpty, isNone, run} = Ember
+const {$, A, ObjectProxy, String: EmberString, get, isEmpty, isNone, isPresent, run} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {selection} from 'ember-frost-list'
@@ -43,6 +43,7 @@ export default Component.extend({
     ])),
     onSelectionChange: PropTypes.func,
     itemKey: PropTypes.string,
+    size: PropTypes.string,
 
     // Options - sub-components
     pagination: PropTypes.EmberComponent,
@@ -51,6 +52,7 @@ export default Component.extend({
     // Options - infinite scroll
     onLoadNext: PropTypes.func,
     onLoadPrevious: PropTypes.func,
+
     // Smoke and mirrors
     alwaysUseDefaultHeight: PropTypes.bool,
     bufferSize: PropTypes.number,
@@ -78,11 +80,11 @@ export default Component.extend({
     return {
       // Options - general
       scrollTop: 0,
+      size: 'medium',
 
       // Smoke and mirrors options
       alwaysUseDefaultHeight: false,
       bufferSize: 10,
-      defaultHeight: 50,
 
       // State
       _rangeState: {
@@ -112,6 +114,29 @@ export default Component.extend({
         }
       })
     })
+  },
+
+  @readOnly
+  @computed('defaultHeight', 'size')
+  listRowHeight (defaultHeight, size) {
+    if (isPresent(defaultHeight)) {
+      return defaultHeight
+    }
+
+    switch (size) {
+      case 'medium':
+        return 50
+      case 'small':
+        return 30
+      default:
+        return 50
+    }
+  },
+
+  @readOnly
+  @computed('listRowHeight')
+  listRowHeightString (listRowHeight) {
+    return EmberString.htmlSafe(`height:${listRowHeight}px`)
   },
 
   // == Functions =============================================================

--- a/addon/styles/_frost-list-item-container.scss
+++ b/addon/styles/_frost-list-item-container.scss
@@ -29,7 +29,6 @@
 .frost-list-item-container-base {
   display: flex;
   flex-direction: row;
-  height: 50px;
   padding-left: 5px;
   transition: background-color .2s;
   background-color: $frost-color-white;

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -15,7 +15,7 @@
     alwaysUseDefaultHeight=alwaysUseDefaultHeight
     bufferSize=bufferSize
     content=items
-    defaultHeight=defaultHeight
+    defaultHeight=listRowHeight
     firstReached=onLoadPrevious
     lastReached=onLoadNext
     scrollPosition=scrollTop

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -15,7 +15,7 @@
     alwaysUseDefaultHeight=alwaysUseDefaultHeight
     bufferSize=bufferSize
     content=items
-    defaultHeight=listRowHeight
+    defaultHeight=defaultHeight
     firstReached=onLoadPrevious
     lastReached=onLoadNext
     scrollPosition=scrollTop

--- a/addon/templates/components/frost-list-item-selection.hbs
+++ b/addon/templates/components/frost-list-item-selection.hbs
@@ -3,5 +3,5 @@
 {{frost-checkbox
   checked=isSelected
   hook=(concat hookPrefix '-checkbox')
-  size='medium'
+  size=size
 }}

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -32,7 +32,7 @@
 {{#frost-list-content-container
   alwaysUseDefaultHeight=alwaysUseDefaultHeight
   bufferSize=bufferSize
-  defaultHeight=defaultHeight
+  defaultHeight=listRowHeight
   hook=(concat hookPrefix '-contentContainer')
   items=_items
   itemKey=itemKey
@@ -50,7 +50,7 @@
     }}
     data-test={{hook (concat hook '-item-container') index=index }}
   >
-    <div class='frost-list-item-container-base'>
+    <div class='frost-list-item-container-base' style={{listRowHeightString}}>
       {{#if itemExpansion}}
         {{frost-list-item-expansion
           hook=(concat hookPrefix '-expansion')
@@ -67,6 +67,7 @@
           hookQualifiers=(hash index=index)
           model=model.content
           isSelected=model.states.isSelected
+          size=size
           onSelect=(action '_select')
         }}
       {{/if}}

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -15,6 +15,7 @@
       <div class='frost-modal-demo-selector-title'>
         Cookbook
         {{#link-to 'simple'}}Basic{{/link-to}}
+        {{#link-to 'size'}}Size{{/link-to}}
         {{#link-to 'infinite'}}Infinite{{/link-to}}
         {{#link-to 'paged'}}Paged{{/link-to}}
       </div>

--- a/tests/dummy/app/pods/size/controller.js
+++ b/tests/dummy/app/pods/size/controller.js
@@ -13,8 +13,8 @@ export default Controller.extend({
 
   // == Properties ============================================================
 
-  expandedItems: A([]),
-  selectedItems: A([]),
+  expandedItems: A(),
+  selectedItems: A(),
   sortOrder: A(['-id']),
   sortingProperties: [
     {label: 'Id', value: 'id'},

--- a/tests/dummy/app/pods/size/controller.js
+++ b/tests/dummy/app/pods/size/controller.js
@@ -1,0 +1,54 @@
+/**
+ * TODO
+ */
+
+import Ember from 'ember'
+const {A, Controller, isEmpty} = Ember
+import computed, {readOnly} from 'ember-computed-decorators'
+import {sort} from 'ember-frost-sort'
+
+export default Controller.extend({
+
+  // == Dependencies ==========================================================
+
+  // == Properties ============================================================
+
+  expandedItems: A([]),
+  selectedItems: A([]),
+  sortOrder: A(['-id']),
+  sortingProperties: [
+    {label: 'Id', value: 'id'},
+    {label: 'Label', value: 'label'}
+  ],
+
+  // == Computed Properties ===================================================
+
+  @readOnly
+  @computed('model.[]', 'sortOrder.[]')
+  items (model, sortOrder) {
+    if (isEmpty(model)) {
+      return []
+    }
+    return sort(model, sortOrder) // Client side sorting
+  },
+
+  // == Functions =============================================================
+
+  // == Lifecycle Hooks =======================================================
+
+  // == Actions ===============================================================
+
+  actions: {
+    onExpansionChange (expandedItems) {
+      this.get('expandedItems').setObjects(expandedItems)
+    },
+
+    onSelectionChange (selectedItems) {
+      this.get('selectedItems').setObjects(selectedItems)
+    },
+
+    onSortingChange (sortOrder) {
+      this.get('sortOrder').setObjects(sortOrder)
+    }
+  }
+})

--- a/tests/dummy/app/pods/size/controller.js
+++ b/tests/dummy/app/pods/size/controller.js
@@ -1,7 +1,3 @@
-/**
- * TODO
- */
-
 import Ember from 'ember'
 const {A, Controller, isEmpty} = Ember
 import computed, {readOnly} from 'ember-computed-decorators'

--- a/tests/dummy/app/pods/size/route.js
+++ b/tests/dummy/app/pods/size/route.js
@@ -1,0 +1,8 @@
+import Ember from 'ember'
+const {Route} = Ember
+
+export default Route.extend({
+  model () {
+    return this.store.findAll('list-item')
+  }
+})

--- a/tests/dummy/app/pods/size/template.hbs
+++ b/tests/dummy/app/pods/size/template.hbs
@@ -1,0 +1,41 @@
+<div class='example-block'>
+  <div class='title'>Default view</div>
+  {{frost-list
+    class='demo'
+    hook='demo'
+    item=(component 'list-item')
+    itemExpansion=(component 'list-item-expansion')
+    items=items
+    expandedItems=expandedItems
+    selectedItems=selectedItems
+    onExpansionChange=(action 'onExpansionChange')
+    onSelectionChange=(action 'onSelectionChange')
+    sorting=(component 'frost-sort'
+      sortOrder=sortOrder
+      sortingProperties=sortingProperties
+      onChange=(action 'onSortingChange')
+    )
+  }}
+</div>
+
+<div class='example-block'>
+  <div class='title'>Small view</div>
+
+  {{frost-list
+    class='demo'
+    hook='demo'
+    item=(component 'list-item')
+    itemExpansion=(component 'list-item-expansion')
+    items=items
+    expandedItems=expandedItems
+    selectedItems=selectedItems
+    size='small'
+    onExpansionChange=(action 'onExpansionChange')
+    onSelectionChange=(action 'onSelectionChange')
+    sorting=(component 'frost-sort'
+      sortOrder=sortOrder
+      sortingProperties=sortingProperties
+      onChange=(action 'onSortingChange')
+    )
+  }}
+</div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -14,6 +14,7 @@ Router.map(function () {
   })
   this.route('infinite')
   this.route('paged')
+  this.route('size')
 })
 
 export default Router

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -82,10 +82,20 @@ $frost-modal-demos-shadow-color: rgba(0, 0, 0, .13);
 .frost-modal-demo-example {
   display: flex;
   flex: 1;
-  flex-direction: row;
+  flex-direction: column;
   height: 100vh;
   padding-left: 20px;
   background-color: $frost-color-lgrey-3;
+
+  .example-block {
+    .title {
+      color: $frost-color-grey-3;
+      font-weight: 500;      
+    }
+  }
+  .example-block ~ .example-block {
+    margin-top: 50px;
+  }
 }
 
 .frost-modal-demo-api,

--- a/tests/integration/components/frost-list-item-selection-test.js
+++ b/tests/integration/components/frost-list-item-selection-test.js
@@ -34,6 +34,7 @@ describe(test.label, function () {
         hook=hook
         isSelected=model.states.isSelected
         model=model
+        size='medium'
         onSelect=(action 'selectAction')
       }}
     `)

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -79,6 +79,103 @@ describe(test.label, function () {
     })
   })
 
+  describe('renders frost-list with size=medium', function () {
+    beforeEach(function () {
+      const list = A([
+        Ember.Object.create({id: '0'})
+      ])
+
+      this.set('items', list)
+
+      this.render(hbs`
+        {{frost-list
+          item=(component 'frost-list-item')
+          items=items
+          hook='myList'
+          size='medium'
+        }}
+      `)
+      return wait()
+    })
+
+    it('sets "frost-list-item" row height to 50px', function () {
+      expect($hook('myList-item-container').height()).to.equal(50)
+    })
+  })
+
+  describe('renders frost-list with size=small', function () {
+    beforeEach(function () {
+      const list = A([
+        Ember.Object.create({id: '0'})
+      ])
+
+      this.set('items', list)
+
+      this.render(hbs`
+        {{frost-list
+          item=(component 'frost-list-item')
+          items=items
+          hook='myList'
+          size='small'
+        }}
+      `)
+      return wait()
+    })
+
+    it('sets "frost-list-item" row height to 30px', function () {
+      expect($hook('myList-item-container').height()).to.equal(30)
+    })
+  })
+
+  describe('renders frost-list with defaultHeight=60', function () {
+    beforeEach(function () {
+      const list = A([
+        Ember.Object.create({id: '0'})
+      ])
+
+      this.set('items', list)
+
+      this.render(hbs`
+        {{frost-list
+          item=(component 'frost-list-item')
+          items=items
+          hook='myList'
+          defaultHeight=60
+        }}
+      `)
+      return wait()
+    })
+
+    it('sets "frost-list-item" row height to 60px.', function () {
+      expect($hook('myList-item-container').height()).to.equal(60)
+    })
+  })
+
+  describe('renders frost-list with size=small and defaultHeight=60', function () {
+    beforeEach(function () {
+      const list = A([
+        Ember.Object.create({id: '0'})
+      ])
+
+      this.set('items', list)
+
+      this.render(hbs`
+        {{frost-list
+          item=(component 'frost-list-item')
+          items=items
+          hook='myList'
+          defaultHeight=60
+          size='small'
+        }}
+      `)
+      return wait()
+    })
+
+    it('size attribute gets ignored.', function () {
+      expect($hook('myList-item-container').height()).to.equal(60)
+    })
+  })
+
   describe('when sort component is set', function () {
     beforeEach(function () {
       registerMockComponent(this, 'mock-sort')

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -127,6 +127,30 @@ describe(test.label, function () {
     })
   })
 
+  describe('renders frost-list with size sets to invalid value', function () {
+    beforeEach(function () {
+      const list = A([
+        Ember.Object.create({id: '0'})
+      ])
+
+      this.set('items', list)
+
+      this.render(hbs`
+        {{frost-list
+          item=(component 'frost-list-item')
+          items=items
+          hook='myList'
+          size='size'
+        }}
+      `)
+      return wait()
+    })
+
+    it('sets "frost-list-item" row height to default 50px', function () {
+      expect($hook('myList-item-container').height()).to.equal(50)
+    })
+  })
+
   describe('renders frost-list with defaultHeight=60', function () {
     beforeEach(function () {
       const list = A([


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Removed** default value for `defaultHeight` property.
* **Updated** `smoke-and-mirror` to consume `listRowHeight` instead of `defaultHeight`.
* **Updated** `frost-checkbox` in `frost-list-item-section`, now it reacts to `size`.
* **Updated** `frost-list-item-container-base` to generate its height based on `listRowHeight`.
 * **Added** new interface `size` that defaults to `medium`.
 * **Added** new computed property `listRowHeight` calculates based on `defaultHeight` and `size`.



