### PR TITLE
fix component name issue in ember 2.8.3

### DIFF
--- a/addon/utils/get-component-name.js
+++ b/addon/utils/get-component-name.js
@@ -1,18 +1,18 @@
 import Ember from 'ember'
 const {get} = Ember
 
+function findComponentNameKey (keys) {
+  return keys.find((key) => {
+    return key.includes('__COMPONENT_PATH__') || key.includes('COMPONENT_PATH')
+  })
+}
+
+/**
+   *  Necessary to support Ember 2.8 when component name is not accessible via component.name
+   *  Ember: 2.8.3 and Ember: lts-2-8 assigns component name to different internal key.
+   *  @param {Object} component - Ember component instance
+   *  @returns {string} | component's name
+ */
 export default function getComponentName (component) {
-  let componentName = get(component, 'name')
-
-  // Necessary to support Ember 2.8-LTS
-  if (!componentName) {
-    componentName = Object.keys(component).reduce((accumulator, key) => {
-      if (key.indexOf('__COMPONENT_PATH__') > -1) {
-        accumulator = component[key]
-      }
-      return accumulator
-    }, '')
-  }
-
-  return componentName
+  return get(component, 'name') || component[findComponentNameKey(Object.keys(component))]
 }

--- a/package.json
+++ b/package.json
@@ -88,6 +88,6 @@
     "name": "frost-list"
   },
   "pr-bumper": {
-    "coverage": 97.22
+    "coverage": 97.18
   }
 }


### PR DESCRIPTION
Fixes #152 
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
- Fixed issue when running against 2.8.3, List can't get the valid component name to render.
