### PR TITLE
Propagate `size` attribute to `frost-checkbox `

### DIFF
--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -49,6 +49,7 @@
     index=index
     listRowHeightString=listRowHeightString
     isAnyItemExpansion=isAnyItemExpansion
+    size=size
     item=(get
       itemDefinitions (get-typed-component-name
         componentKeyNamesForTypes itemTypeKey model (get componentKeyNames 'item') 'default'

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -109,7 +109,13 @@ describe(test.label, function () {
         Ember.Object.create({id: '0'})
       ])
 
-      this.set('items', list)
+      this.setProperties({
+        items: list,
+        selectedItems: A([]),
+        onSelectionChange: (selectedItems) => {
+          this.get('selectedItems').setObjects(selectedItems)
+        }
+      })
 
       this.render(hbs`
         {{frost-list
@@ -117,6 +123,8 @@ describe(test.label, function () {
           items=items
           hook='myList'
           size='small'
+          selectedItems=selectedItems
+          onSelectionChange=onSelectionChange
         }}
       `)
       return wait()
@@ -124,6 +132,16 @@ describe(test.label, function () {
 
     it('sets "frost-list-item" row height to 30px', function () {
       expect($hook('myList-itemContent-item-container').height()).to.equal(30)
+    })
+
+    it('should display small checkbox', function () {
+      expect($hook('myList-itemContent-selection-checkbox').hasClass('small')).to.eql(true)
+    })
+
+    it('after click, should display small checkbox', function () {
+      const $el = $hook('myList-itemContent-selection-checkbox')
+      $el.click()
+      expect($el.hasClass('small')).to.eql(true)
     })
   })
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** issue that `size` attribute didn't propagate down to `frost-checkbox`
