### PR TITLE
Solve frost-list sort overflow

### DIFF
--- a/addon/styles/_frost-list-expansion.scss
+++ b/addon/styles/_frost-list-expansion.scss
@@ -10,6 +10,7 @@
     padding: 0 5px;
     color: $frost-color-blue-1;
     line-height: 30px;
+    white-space: nowrap;
 
     &:hover {
       background-color: $frost-list-expansion-item-hover-color;

--- a/addon/styles/_frost-list-header.scss
+++ b/addon/styles/_frost-list-header.scss
@@ -18,7 +18,7 @@
 .frost-list-header-end {
   display: flex;
   flex-direction: row;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-end;
   margin-left: auto;
 }

--- a/addon/styles/_frost-list-header.scss
+++ b/addon/styles/_frost-list-header.scss
@@ -6,25 +6,6 @@
   &.paged {
     padding-right: $frost-list-scroll-rail-gutter-width;
   }
-
-  .frost-list-header-sort-title {
-    color: $frost-color-grey-4;
-    font-size: $frost-font-s;
-    white-space: nowrap;
-  }
-
-  .frost-sort {
-    flex-wrap: wrap;
-
-    .frost-sort-item {
-      height: 100%;
-    }
-
-    .frost-sort-title {
-      display: none;
-    }
-
-  }
 }
 
 .frost-list-header-divider {

--- a/addon/styles/_frost-list-header.scss
+++ b/addon/styles/_frost-list-header.scss
@@ -2,10 +2,28 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  height: 45px;
 
   &.paged {
     padding-right: $frost-list-scroll-rail-gutter-width;
+  }
+
+  .frost-list-header-sort-title {
+    color: $frost-color-grey-4;
+    font-size: $frost-font-s;
+    white-space: nowrap;
+  }
+
+  .frost-sort {
+    flex-wrap: wrap;
+
+    .frost-sort-item {
+      height: 100%;
+    }
+
+    .frost-sort-title {
+      display: none;
+    }
+
   }
 }
 
@@ -19,7 +37,7 @@
 .frost-list-header-end {
   display: flex;
   flex-direction: row;
-  align-items: center;
-  height: 45px;
+  align-items: flex-start;
+  justify-content: flex-end;
   margin-left: auto;
 }

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -2,6 +2,7 @@
 
 <div class='frost-list-header {{if pagination 'paged'}}'>
   {{#if sorting}}
+    <div class='frost-list-header-sort-title'>Sort by:</div>
     {{component sorting
       hook=(concat hookPrefix '-sorting')
     }}

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -2,7 +2,6 @@
 
 <div class='frost-list-header {{if pagination 'paged'}}'>
   {{#if sorting}}
-    <div class='frost-list-header-sort-title'>Sort by:</div>
     {{component sorting
       hook=(concat hookPrefix '-sorting')
     }}

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
     "ember-frost-core": "^3.0.1",
-    "ember-frost-sort": "^8.0.2",
+    "ember-frost-sort": "^8.0.3",
     "ember-math-helpers": "2.0.6",
     "smoke-and-mirrors": "github:ciena-frost/smoke-and-mirrors",
     "ua-parser-js": "^0.7.12"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "5.6.0",
     "ember-frost-core": "^3.0.1",
-    "ember-frost-sort": "^8.0.0",
+    "ember-frost-sort": "^8.0.2",
     "ember-math-helpers": "2.0.6",
     "smoke-and-mirrors": "github:ciena-frost/smoke-and-mirrors",
     "ua-parser-js": "^0.7.12"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change


## Issue:
![screen shot 2017-11-20 at 12 45 30 pm](https://user-images.githubusercontent.com/9057680/33033156-7d2bffe0-cdf1-11e7-8103-4897f9e1b221.png)

## Resolution:
![screen shot 2017-11-20 at 10 49 37 am](https://user-images.githubusercontent.com/9057680/33033189-8c61b7f2-cdf1-11e7-8b38-4474d702e285.png)


# CHANGELOG
* Fixes #161 : Have frost-list flex-wrap sort if it overflows
