### PR TITLE
Add support for dynamic row height.

### DIFF
--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -37,6 +37,7 @@ export default Component.extend({
       PropTypes.EmberObject,
       PropTypes.object
     ])),
+    isDynamicRowHeight: PropTypes.bool,
     itemExpansion: PropTypes.oneOfType([
       PropTypes.null,
       PropTypes.EmberComponent
@@ -103,6 +104,7 @@ export default Component.extend({
       // Options - general
       scrollTop: 0,
       size: 'medium',
+      isDynamicRowHeight: false,
       itemTypeKey: 'itemType',
       componentKeyNames: {
         item: 'itemName',
@@ -144,8 +146,12 @@ export default Component.extend({
   },
 
   @readOnly
-  @computed('defaultHeight', 'size')
-  listRowHeight (defaultHeight, size) {
+  @computed('defaultHeight', 'size', 'isDynamicRowHeight')
+  listRowHeight (defaultHeight, size, isDynamicRowHeight) {
+    if (isDynamicRowHeight) {
+      return
+    }
+
     let listRowHeight
 
     if (isPresent(defaultHeight)) {
@@ -170,7 +176,7 @@ export default Component.extend({
   @readOnly
   @computed('listRowHeight')
   listRowHeightString (listRowHeight) {
-    return EmberString.htmlSafe(`height:${listRowHeight}px`)
+    return listRowHeight ? EmberString.htmlSafe(`height:${listRowHeight}px`) : ''
   },
 
   @readOnly

--- a/tests/dummy/app/pods/components/list-item-dynamic-height/_styles.scss
+++ b/tests/dummy/app/pods/components/list-item-dynamic-height/_styles.scss
@@ -5,9 +5,9 @@
 }
 
 .list-item-dynamic-height-large-placeholder {
+  align-self: center;
   width: 200px;
   height: 100px;
-  align-self: center;
   color: $frost-color-grey-5;
   font-style: italic;
 }

--- a/tests/dummy/app/pods/components/list-item-dynamic-height/_styles.scss
+++ b/tests/dummy/app/pods/components/list-item-dynamic-height/_styles.scss
@@ -1,0 +1,13 @@
+.list-item-dynamic-height-placeholder {
+  align-self: center;
+  color: $frost-color-grey-5;
+  font-style: italic;
+}
+
+.list-item-dynamic-height-large-placeholder {
+  width: 200px;
+  height: 100px;
+  align-self: center;
+  color: $frost-color-grey-5;
+  font-style: italic;
+}

--- a/tests/dummy/app/pods/components/list-item-dynamic-height/component.js
+++ b/tests/dummy/app/pods/components/list-item-dynamic-height/component.js
@@ -1,0 +1,4 @@
+import FrostListItem from 'ember-frost-list/components/frost-list-item'
+
+export default FrostListItem.extend({
+})

--- a/tests/dummy/app/pods/components/list-item-dynamic-height/template.hbs
+++ b/tests/dummy/app/pods/components/list-item-dynamic-height/template.hbs
@@ -1,0 +1,6 @@
+<div class='frost-list-item-element-block {{css}}-placeholder'>
+  Placeholder - {{model.label}} - {{model.id}}
+</div>
+{{#if (eq model.id '398')}}
+  <div class='{{css}}-large-placeholder'></div>
+{{/if}}

--- a/tests/dummy/app/pods/size/template.hbs
+++ b/tests/dummy/app/pods/size/template.hbs
@@ -39,3 +39,26 @@
     )
   }}
 </div>
+
+<div class='example-block'>
+  <div class='title'>Dynamic content height</div>
+
+  {{frost-list
+    class='demo'
+    hook='demo'
+    isDynamicRowHeight=true
+    item=(component 'list-item-dynamic-height')
+    itemExpansion=(component 'list-item-expansion')
+    items=items
+    expandedItems=expandedItems
+    selectedItems=selectedItems
+    size='small'
+    onExpansionChange=(action 'onExpansionChange')
+    onSelectionChange=(action 'onSelectionChange')
+    sorting=(component 'frost-sort'
+      sortOrder=sortOrder
+      sortingProperties=sortingProperties
+      onChange=(action 'onSortingChange')
+    )
+  }}
+</div>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -3,6 +3,7 @@
 @import 'tests/dummy/app/pods/components/list-item-typed/styles';
 @import 'tests/dummy/app/pods/components/list-item-type-a/styles';
 @import 'tests/dummy/app/pods/components/list-item-type-b/styles';
+@import 'tests/dummy/app/pods/components/list-item-dynamic-height/styles';
 @import 'tests/dummy/app/pods/components/list-item-expansion/styles';
 @import 'tests/dummy/app/pods/components/list-item-typed-expansion/styles';
 @import 'tests/dummy/app/pods/components/list-item-type-a-expansion/styles';
@@ -91,11 +92,12 @@ $frost-modal-demos-shadow-color: rgba(0, 0, 0, .13);
   height: 100vh;
   padding-left: 20px;
   background-color: $frost-color-lgrey-3;
+  overflow: auto;
 
   .example-block {
     .title {
       color: $frost-color-grey-3;
-      font-weight: 500;      
+      font-weight: 500;
     }
   }
   .example-block ~ .example-block {

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -218,6 +218,32 @@ describe(test.label, function () {
     })
   })
 
+  describe('renders frost-list with isDynamicRowHeight set to true', function () {
+    beforeEach(function () {
+      const list = A([
+        Ember.Object.create({id: '0'})
+      ])
+
+      this.set('items', list)
+
+      this.render(hbs`
+        {{frost-list
+          hook='myList'
+          item=(component 'frost-list-item')
+          items=items
+          isDynamicRowHeight=true
+          defaultHeight=60
+          size='small'
+        }}
+      `)
+      return wait()
+    })
+
+    it('should ignore both defaultHeight and size.', function () {
+      expect($hook('myList-itemContent-item-container').height()).to.equal(0)
+    })
+  })
+
   describe('when sort component is set', function () {
     beforeEach(function () {
       registerMockComponent(this, 'mock-sort')


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** isDynamicRowHeight API to support dynamic list row height.
