### PR TITLE
small fix to check if selectionChange is set before executing anythin…

### DIFF
--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -332,7 +332,9 @@ export default Component.extend({
         selection.basic(clonedSelectedItems, item, _rangeState, _itemComparator)
       }
 
-      this.onSelectionChange(clonedSelectedItems)
+      if (this.onSelectionChange) {
+        this.onSelectionChange(clonedSelectedItems)
+      }
     }
   }
 })


### PR DESCRIPTION
…g related to it

### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Fixed console errors when no `onSelectionChange` is given to the frost list.