### PR TITLE
fixed _select call when there is no onSelectionChange

### DIFF
--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -317,22 +317,22 @@ export default Component.extend({
     },
 
     _select ({isRangeSelect, isSpecificSelect, item}) {
-      const items = this.get('items')
-      const itemKey = this.get('itemKey')
-      const _itemComparator = this.get('_itemComparator')
-      const clonedSelectedItems = A(this.get('selectedItems').slice())
-      const _rangeState = this.get('_rangeState')
-
-      // Selects are proccessed in order of precedence: specific, range, basic
-      if (isSpecificSelect) {
-        selection.specific(clonedSelectedItems, item, _rangeState, _itemComparator)
-      } else if (isRangeSelect) {
-        selection.range(items, clonedSelectedItems, item, _rangeState, _itemComparator, itemKey)
-      } else {
-        selection.basic(clonedSelectedItems, item, _rangeState, _itemComparator)
-      }
-
       if (this.onSelectionChange) {
+        const items = this.get('items')
+        const itemKey = this.get('itemKey')
+        const _itemComparator = this.get('_itemComparator')
+        const clonedSelectedItems = A(this.get('selectedItems').slice())
+        const _rangeState = this.get('_rangeState')
+
+        // Selects are proccessed in order of precedence: specific, range, basic
+        if (isSpecificSelect) {
+          selection.specific(clonedSelectedItems, item, _rangeState, _itemComparator)
+        } else if (isRangeSelect) {
+          selection.range(items, clonedSelectedItems, item, _rangeState, _itemComparator, itemKey)
+        } else {
+          selection.basic(clonedSelectedItems, item, _rangeState, _itemComparator)
+        }
+
         this.onSelectionChange(clonedSelectedItems)
       }
     }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
fixed _select call when there is no onSelectionChange to prevent console error.
