### PR TITLE
Make spacing consistent between non-expandable and expandable list items

### DIFF
--- a/addon/styles/_frost-list-item-container.scss
+++ b/addon/styles/_frost-list-item-container.scss
@@ -33,7 +33,7 @@
 .frost-list-item-container-base {
   display: flex;
   flex-direction: row;
-  padding-left: 5px;
+  padding-left: 10px;
   transition: background-color .2s;
   background-color: $frost-color-white;
 }

--- a/addon/styles/_frost-list-item-expansion.scss
+++ b/addon/styles/_frost-list-item-expansion.scss
@@ -1,6 +1,6 @@
 .frost-list-item-expansion {
   align-self: center;
-  margin: 0 5px;
+  margin: 0 7px 0 0;
   padding: 5px 5px 1px; // FIXME Bottom is 1px to compensate for svg sizing
   color: $frost-color-grey-5;
   cursor: pointer;


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

*no expansion - 10px left margin*
<img width="293" alt="screen shot 2017-12-13 at 4 21 51 pm" src="https://user-images.githubusercontent.com/756699/33969383-d1d5f14e-e021-11e7-9ecf-10d1d7240ba3.png">

*expansion - 10px left margin and 7px between checkbox and chevron*
<img width="306" alt="screen shot 2017-12-13 at 4 22 05 pm" src="https://user-images.githubusercontent.com/756699/33969386-d3e3931a-e021-11e7-9a3d-7504f00029c1.png">

# CHANGELOG

* Updated margin/padding in the list-item to provide consistent spacing and follow UX specs
