### PR TITLE
Add min-height style for frost-list-header

### DIFF
--- a/addon/styles/_frost-list-header.scss
+++ b/addon/styles/_frost-list-header.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  min-height: 45px;
 
   &.paged {
     padding-right: $frost-list-scroll-rail-gutter-width;


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** `min-height` of `45px` to `frost-list-header`
