### PR TITLE
Enable multi-select behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Attribute`        | `itemTypeKey`        | `string`         |       | Optional: With `itemTypeKey` set, it will be used to identify a list item's type. It will also be used for accessing the hash of components within `componentKeyNamesForTypes`. |
 | `Attribute`        | `itemDefinitions`    | `hash`           |       | Optional: A set of components that are to be used in the list as the `item` component. Note that this had to be used in conjunction with `componentKeyNamesForTypes` |
 | `Attribute`        | `itemExpansionDefinitions` | `hash`     |       | Optional: A set of components that are to be used in the list as the `itemExpansion` component. Note that this had to be used in conjunction with `componentKeyNamesForTypes` |
+| `Attribute`        | `disableDeselectAll` | `boolean`     | false    | Optional: disables deselect all click turning frost list into a multi-select type list |
 
 
 ### Infinite scroll

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -31,6 +31,7 @@ export default Component.extend({
     ])).isRequired,
 
     // Options - general
+    disableDeselectAll: PropTypes.bool,
     expandedItems: PropTypes.arrayOf(PropTypes.oneOfType([
       PropTypes.EmberObject,
       PropTypes.object
@@ -100,6 +101,7 @@ export default Component.extend({
   getDefaultProps () {
     return {
       // Options - general
+      disableDeselectAll: false,
       scrollTop: 0,
       size: 'medium',
       isDynamicRowHeight: false,
@@ -320,13 +322,20 @@ export default Component.extend({
       this.onExpansionChange(clonedItems)
     },
 
+    /* eslint-disable complexity */
     _select ({isRangeSelect, isSpecificSelect, item}) {
+      isRangeSelect = !!isRangeSelect // isRangeSelect can come in as undefined
       if (this.onSelectionChange) {
         const items = this.get('items')
         const itemKey = this.get('itemKey')
         const _itemComparator = this.get('_itemComparator')
         const clonedSelectedItems = A(this.get('selectedItems').slice())
         const _rangeState = this.get('_rangeState')
+
+        if (isRangeSelect === false && this.get('disableDeselectAll') === true) {
+          // Ensure we are not interrupting a range select prior to forcing a isSpecificSelect
+          isSpecificSelect = true
+        }
 
         // Selects are proccessed in order of precedence: specific, range, basic
         if (isSpecificSelect) {
@@ -340,5 +349,6 @@ export default Component.extend({
         this.onSelectionChange(clonedSelectedItems)
       }
     }
+    /* eslint-enable complexity */
   }
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* Added disableDeselectAll. If true, clicking outside of the checkbox in a list item will no longer deselect all of the other items.
