### PR TITLE
#176 added full class to frost-list for frost-scroll

### DIFF
--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -2,6 +2,7 @@
 {{#if pagination}}
   {{#frost-scroll
     hook=(concat hookPrefix '-scroll')
+    class='full'
   }}
     {{#each items key=_eachItemKey as |model index|}}
       {{yield model index}}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Closes #176 

# CHANGELOG
* **Added** `full` class in `frost-list` for `frost-scroll` so popover items display correctly
