### PR TITLE
change the syntax for requiring smoke-and-mirror

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ember-math-helpers": "2.0.6",
     "ember-prop-types": "^6.0.1",
     "ember-truth-helpers": "^1.3.0",
-    "smoke-and-mirrors": "git://git@github.com/ciena-frost/smoke-and-mirrors.git",
+    "smoke-and-mirrors": "git://github.com/ciena-frost/smoke-and-mirrors.git",
     "ua-parser-js": "^0.7.17"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "ember-math-helpers": "2.0.6",
     "ember-prop-types": "^6.0.1",
     "ember-truth-helpers": "^1.3.0",
-    "smoke-and-mirrors": "github:ciena-frost/smoke-and-mirrors",
+    "smoke-and-mirrors": "git://git@github.com/ciena-frost/smoke-and-mirrors.git",
     "ua-parser-js": "^0.7.17"
   },
   "ember-addon": {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
Updated the syntax for requiring `smoke-and-mirror`.