### PR TITLE
fix wrapping (UX specs)

### DIFF
--- a/addon/styles/_frost-list-header.scss
+++ b/addon/styles/_frost-list-header.scss
@@ -19,6 +19,7 @@
 .frost-list-header-end {
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
   margin-left: auto;

--- a/addon/styles/_frost-list-pagination.scss
+++ b/addon/styles/_frost-list-pagination.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  white-space: nowrap;
 }
 
 .frost-list-pagination-left {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

![ember-frost-list_testbed](https://user-images.githubusercontent.com/9057680/37048763-dd6ac74e-213c-11e8-86a9-3fa979c67298.png)
![ember-frost-list_testbed](https://user-images.githubusercontent.com/9057680/37048814-fd722a00-213c-11e8-98bd-454c24d54eaf.png)

# CHANGELOG
* Update frost-list to match new UX specs (wrap paging when sort does, and ensure page buttons are one same line)

