### PR TITLE
update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * **Removed** ignoring of `package-lock.json` file
 * **Added** `package-lock.json` file
 * **Updated** Travis CI scripts to allow non-exact node version
+* **Removed** is-lead-selection.js helper since it is not being used
 
 # 9.2.1 (2018-03-07)
 * Update frost-list to match new UX specs (wrap paging when sort does, and ensure page buttons are one same line)
@@ -110,7 +111,7 @@ fixed _select call when there is no onSelectionChange to prevent console error.
 * Remove unused `ember-simple-uuid` dependency
 
 # 6.1.3 (2017-11-13)
-* Closes #157 
+* Closes #157
 
 
 # 6.1.2 (2017-10-23)
@@ -188,7 +189,7 @@ fixed _select call when there is no onSelectionChange to prevent console error.
 
 # 5.5.6 (2017-04-26)
 * **Split** states and record for a list item
-* **Fixed** #129 
+* **Fixed** #129
 * **Changed** version of `smoke-and-mirrors`
 * **Added** blueprint check
 
@@ -381,18 +382,18 @@ This change is [<img src="https://reviewable.io/review_button.svg" height="34" a
 
 # 1.0.0
 
-* **Removed** internal record state management. 
-* **Removed** small/medium/large detail level support. 
+* **Removed** internal record state management.
+* **Removed** small/medium/large detail level support.
 * **Removed** support for list block format rendering.
 * **Updated**  user interface to support new component driven API and data driven API.
-* **Updated** css to serve new template layout. 
-* **Updated** to `smoke-and-mirror: 0.5.4`. 
+* **Updated** css to serve new template layout.
+* **Updated** to `smoke-and-mirror: 0.5.4`.
 * **Added**  a bunch of Mixins to support common list operation.
 * **Added**  list expand/collapse control component.
 * **Added**  live demo with source code generating.
 * **Added**  hook for testing.
 * **Added**  README
-* **Fixed**  content shifting when item gets selected. 
+* **Fixed**  content shifting when item gets selected.
 
 # 0.7.8
 No CHANGELOG section found in Pull Request description.


### PR DESCRIPTION
# Overview

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary
Provide a general summary of the issue addressed in the title above

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Screenshots or recordings
Please provide screenshots or recordings if this PR is modifying the visual UI or UX.

## Checklist
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have evaluated if the _README.md_ documentation needs to be updated
* [ ] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [ ] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [X] #none#
- [ ] #patch#
- [ ] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG
* **Updated** CHANGELOG with `Removed is-lead-selection.js helper since it is not being used`