### PR TITLE
Add isLoading flag to show loading icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Attribute`        | `disableDeselectAll` | `boolean`        | false | Optional: disables deselect all click turning frost list into a multi-select type list |
 | `Attribute`        | `expansionType`      | `string`         |       | Optional: controls the expand/collapse capability for items in the list. If set to `always`, items will always be expanded, and the ability to expand/collapse items will be disabled. If set to `initial`, all items will be expanded initially, but may still be collapsed/expanded as usual. |
 | `Attribute`        | `singleSelection`    | `boolean`        | false | Optional: disables multiple selection entirely and displays radio buttons instead of checkboxes in frost-list-item-selection to clarify the list's behavior. |
+| `Attribute`        | `isLoading`    | `boolean`        | false | Optional: shows loading indicator in middle of list if true |
 
 
 ### Infinite scroll
@@ -101,7 +102,7 @@ In these cases pagination may optionally be used
 }}
 ```
 
-The onChange action will receive the `page` being requested, which can be combined with 
+The onChange action will receive the `page` being requested, which can be combined with
 the `itemsPerPage` to make an API request and provide the new items for the list
 
 ```

--- a/addon/components/frost-list-content-container.js
+++ b/addon/components/frost-list-content-container.js
@@ -22,7 +22,8 @@ export default Component.extend({
   // == PropTypes =============================================================
 
   propTypes: {
-    itemKey: PropTypes.string
+    itemKey: PropTypes.string,
+    isLoading: PropTypes.bool
   },
 
   getDefaultProps () {

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -69,6 +69,7 @@ export default Component.extend({
     ]),
     expansionType: PropTypes.string,
     singleSelection: PropTypes.bool,
+    isLoading: PropTypes.bool,
 
     // Options - sub-components
     pagination: PropTypes.EmberComponent,
@@ -114,6 +115,7 @@ export default Component.extend({
         itemExpansion: 'itemExpansionName'
       },
       singleSelection: false,
+      isLoading: false,
 
       // Smoke and mirrors options
       alwaysUseDefaultHeight: false,

--- a/addon/styles/_frost-list-content-container.scss
+++ b/addon/styles/_frost-list-content-container.scss
@@ -33,6 +33,17 @@
       padding-right: $frost-list-scroll-rail-gutter-width;
     }
   }
+
+  .frost-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+
+    > svg {
+      height: 100px;
+    }
+  }
 }
 
 // The scroll rail requires a padding offset, so a typical border-top/border-bottom

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -1,5 +1,9 @@
 {{! Template for the frost-list-content-container component }}
-{{#if pagination}}
+{{#if isLoading}}
+  {{frost-loading
+    hook=(concat hookPrefix '-loading')
+  }}
+{{else if pagination}}
   {{#frost-scroll
     hook=(concat hookPrefix '-scroll')
     class='full'

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -40,6 +40,7 @@
   scrollTop=scrollTop
   onLoadNext=onLoadNext
   onLoadPrevious=onLoadPrevious
+  isLoading=isLoading
   as |model index|
 }}
   {{frost-list-item-content

--- a/tests/integration/components/frost-list-content-container-test.js
+++ b/tests/integration/components/frost-list-content-container-test.js
@@ -79,4 +79,19 @@ describe(test.label, function () {
       expect($hook('myListContentContainer-scroll')).to.have.length(1)
     })
   })
+
+  describe('when isLoading property is set', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-list-content-container
+          hook=hook
+          isLoading=true
+        }}
+      `)
+    })
+
+    it('should show loading indicator', function () {
+      expect($hook('myListContentContainer-loading')).to.have.length(1)
+    })
+  })
 })


### PR DESCRIPTION
# Overview
Add an optional `isLoading` flag to show a loading icon in the middle of the list

## Does this PR close an existing issue?
No PR should be opened without opening an issue first.  Any change needs to be discussed before proceeding.

## Summary

## Issue Number(s)
Which issue(s) does this PR address?

Put `Closes #XXXX` below to auto-close the issue that this PR addresses:

* Closes #

## Screenshots or recordings

<img width="1017" alt="screen shot 2018-07-26 at 10 35 56 am" src="https://user-images.githubusercontent.com/12944605/43269681-61d74d74-90c1-11e8-8748-5d96dbca819d.png">

## Checklist
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have evaluated if the _README.md_ documentation needs to be updated
* [x] I have evaluated if the _/tests/dummy/_ app needs to be modified
* [ ] I have evaluated if DocBlock headers needed to be added or updated
* [x] I have verified that lint and tests pass locally with my changes
* [ ] If a fork of a dependent package had to be made to address the issue this PR closes:
  * [ ] I noted in the fork's _README.md_ the reason the fork was created
  * [ ] I have opened an upstream issue detailing what was deficient about the dependency
  * [ ] I have opened an upstream PR addressing this deficiency
  * [ ] I have opened an issue in this repository to track this PR and schedule the removal of the usage of the fork


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

Examples:
* **NONE**
  * _README.md_ changes
  * test additions
  * changes to files that are not used by a consuming application (_.travis.yml_, _.gitignore_, etc)
* **PATCH**
  * backwards-compatible bug fix
    * nothing about how to use the code has changed
    * nothing about the outcome of the code has changed (though it likely corrected it)
  * changes to demo app (_/tests/dummy/_)
* **MINOR**
  * adding functionality in a backwards-compatible manner
    * nothing about how used to use the code has changed but using it in a new way will do new things
    * nothing about the outcome of the code has changed without having to first use it in a new way
    * addition of new CSS selectors
    * addition of new `ember-hook` selectors
* **MAJOR**
  * incompatible API change
    * using the code how used to will cease working
    * using the code how used to will have a different outcome
    * any changes to CSS selector names
    * any removal of CSS selectors
    * any changes to `ember-hook` selectors
    * possibly changes to test helpers (depends on the changes made)
  * any changes to the **_dependencies_** entry in the _package.json_ file

# CHANGELOG

* Add optional `isLoading` flag to show loading indicator