### PR TITLE
Vertical collection for paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ Detailed API and example usage can be found in the sample application in tests/d
 | `Attribute`        | `expansionType`      | `string`         |       | Optional: controls the expand/collapse capability for items in the list. If set to `always`, items will always be expanded, and the ability to expand/collapse items will be disabled. If set to `initial`, all items will be expanded initially, but may still be collapsed/expanded as usual. |
 | `Attribute`        | `singleSelection`    | `boolean`        | false | Optional: disables multiple selection entirely and displays radio buttons instead of checkboxes in frost-list-item-selection to clarify the list's behavior. |
 | `Attribute`        | `isLoading`    | `boolean`        | false | Optional: shows loading indicator in middle of list if true |
-
+| `Attribute`        | `pagination`    | `component`        |    | Optional: When set enables pagination. Placing component in at the end of frost-list header|
+| `Attribute`        | `useVerticalCollectionForPagination`    | `boolean`        |  false  | Optional: When `true` and `pagination` is set `vertical-collection` will be used. By default `frost-list` uses `each` helper if `pagination` is set |
 
 ### Infinite scroll
 
@@ -93,11 +94,11 @@ In these cases pagination may optionally be used
 
 ```
 {{frost-list
-  pagination=(hash
-    itemsPerPage=
-    page=
-    total=
-    onChange=
+  pagination=(component 'frost-list-pagination'
+      itemsPerPage=
+      page=
+      total=
+      onChange=
   )
 }}
 ```
@@ -127,11 +128,11 @@ actions: {
 Pagination by default uses the simple `each` helper for it's list rather than vertical collection (since vertical collection is too extreme for pages that have very few items). In the case you wish to still use vertical collection (ideal when you wish to not render all items in the list) you can use:
 ```
 {{frost-list
-  pagination=(hash
-    itemsPerPage=
-    page=
-    total=
-    onChange=
+  pagination=(component 'frost-list-pagination'
+      itemsPerPage=
+      page=
+      total=
+      onChange=
   )
   useVerticalCollectionForPagination=true
 }}

--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ actions: {
 }
 ```
 
+Pagination by default uses the simple `each` helper for it's list rather than vertical collection (since vertical collection is too extreme for pages that have very few items). In the case you wish to still use vertical collection (ideal when you wish to not render all items in the list) you can use:
+```
+{{frost-list
+  pagination=(hash
+    itemsPerPage=
+    page=
+    total=
+    onChange=
+  )
+  useVerticalCollectionForPagination=true
+}}
+```
+
 ## Testing with ember-hook
 
 The list component is accessible using ember-hook:

--- a/addon/components/frost-list.js
+++ b/addon/components/frost-list.js
@@ -73,6 +73,7 @@ export default Component.extend({
 
     // Options - sub-components
     pagination: PropTypes.EmberComponent,
+    useVerticalCollectionForPagination: PropTypes.bool,
     sorting: PropTypes.EmberComponent,
 
     // Options - infinite scroll
@@ -120,6 +121,9 @@ export default Component.extend({
       // Smoke and mirrors options
       alwaysUseDefaultHeight: false,
       bufferSize: 10,
+
+      // Pagination options
+      useVerticalCollectionForPagination: false,
 
       // State
       _rangeState: {

--- a/addon/templates/components/frost-list-content-container.hbs
+++ b/addon/templates/components/frost-list-content-container.hbs
@@ -3,7 +3,7 @@
   {{frost-loading
     hook=(concat hookPrefix '-loading')
   }}
-{{else if pagination}}
+{{else if (and pagination (not useVerticalCollectionForPagination))}}
   {{#frost-scroll
     hook=(concat hookPrefix '-scroll')
     class='full'

--- a/addon/templates/components/frost-list.hbs
+++ b/addon/templates/components/frost-list.hbs
@@ -37,6 +37,7 @@
   items=_items
   itemKey=itemKey
   pagination=pagination
+  useVerticalCollectionForPagination=useVerticalCollectionForPagination
   scrollTop=scrollTop
   onLoadNext=onLoadNext
   onLoadPrevious=onLoadPrevious

--- a/tests/integration/components/frost-list-test.js
+++ b/tests/integration/components/frost-list-test.js
@@ -299,7 +299,10 @@ describe(test.label, function () {
   describe('when pagination component is set', function () {
     beforeEach(function () {
       registerMockComponent(this, 'mock-pagination')
-      this.set('items', A())
+      this.setProperties({
+        items: A(),
+        useVerticalCollectionForPagination: false
+      })
 
       this.render(hbs`
         {{frost-list
@@ -307,6 +310,7 @@ describe(test.label, function () {
           items=items
           hook='myList'
           pagination=(component 'mock-pagination' class='mock-pagination')
+          useVerticalCollectionForPagination=useVerticalCollectionForPagination
         }}
       `)
       return wait()
@@ -334,6 +338,19 @@ describe(test.label, function () {
 
     it('should have the "paged" class set on "frost-list-content-container-bottom-border"', function () {
       expect(this.$('.frost-list-content-container-bottom-border')).to.have.class('paged')
+    })
+
+    it('should not use vertical collection', function () {
+      expect(this.$('vertical-collection')).to.have.length(0)
+    })
+
+    describe('when useVerticalCollectionForPagination is set to true', function () {
+      beforeEach(function () {
+        this.set('useVerticalCollectionForPagination', true)
+      })
+      it('should use vertical collection', function () {
+        expect(this.$('vertical-collection')).to.have.length(1)
+      })
     })
   })
 


### PR DESCRIPTION
# Overview

## Summary
Add flag to use `vertical collection` in the case of paging. This is useful when your page sizes are massive (like 200). Greatly improves the performance in these cases


# Semver

**This project uses [semver](http://semver.org), please check the scope of this PR:**

- [ ] #none#
- [ ] #patch#
- [x] #minor#
- [ ] #major#

# CHANGELOG

* **Add** flag `useVerticalCollectionForPagination` that allows a consumer to use `vertical-collection` during pagination
